### PR TITLE
Admin browses acps with jacoco

### DIFF
--- a/DropMate_Backend/pom.xml
+++ b/DropMate_Backend/pom.xml
@@ -86,6 +86,33 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.8</version>
+
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven-surefire-plugin.version}</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/DropMate_Backend/pom.xml
+++ b/DropMate_Backend/pom.xml
@@ -47,6 +47,29 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>1.17.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mysql</artifactId>
+			<version>1.17.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>1.17.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>spring-mock-mvc</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -34,7 +34,7 @@ public class AdminController {
     }
 
     /** This method returns all the ACP's associated with the Platform */
-    @GetMapping("/acp/")
+    @GetMapping("/acp")
     public ResponseEntity<List<AssociatedCollectionPoint>> getAllACP(){
         return ResponseEntity.ok().body(adminService.getAllACP());
     }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -1,8 +1,12 @@
 package tqs.dropmate.dropmate_backend.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tqs.dropmate.dropmate_backend.datamodel.*;
+import tqs.dropmate.dropmate_backend.services.ACPService;
+import tqs.dropmate.dropmate_backend.services.AdminService;
+import tqs.dropmate.dropmate_backend.services.StoreService;
 import tqs.dropmate.dropmate_backend.utils.SuccessfulRequest;
 
 import java.util.List;
@@ -12,6 +16,15 @@ import java.util.Map;
 @RequestMapping("dropmate/admin")
 @CrossOrigin
 public class AdminController {
+    private AdminService adminService;
+    private ACPService acpService;
+    private StoreService storeService;
+
+    public AdminController(AdminService adminService, ACPService acpService, StoreService storeService) {
+        this.adminService = adminService;
+        this.acpService = acpService;
+        this.storeService = storeService;
+    }
 
     /** Method for the DropMate administrator login */
     @PostMapping("/login")
@@ -23,7 +36,7 @@ public class AdminController {
     /** This method returns all the ACP's associated with the Platform */
     @GetMapping("/acp/")
     public ResponseEntity<List<AssociatedCollectionPoint>> getAllACP(){
-        return null;
+        return ResponseEntity.ok().body(adminService.getAllACP());
     }
 
     /** This method is used to associate a new ACP with the platform */

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/datamodel/AssociatedCollectionPoint.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/datamodel/AssociatedCollectionPoint.java
@@ -42,6 +42,15 @@ public class AssociatedCollectionPoint {
     @Column
     private String managerContact;
 
+    public AssociatedCollectionPoint(String name, String email, String city, String address, String telephoneNumber, Integer deliveryLimit) {
+        this.name = name;
+        this.email = email;
+        this.city = city;
+        this.address = address;
+        this.telephoneNumber = telephoneNumber;
+        this.deliveryLimit = deliveryLimit;
+    }
+
     @ElementCollection
     @CollectionTable(name = "acp_operational_details", joinColumns = @JoinColumn(name = "acpId"))
     @MapKeyColumn(name = "statistic_name")

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/AssociatedCollectionPointRepository.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/AssociatedCollectionPointRepository.java
@@ -1,0 +1,9 @@
+package tqs.dropmate.dropmate_backend.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
+
+@Repository
+public interface AssociatedCollectionPointRepository extends JpaRepository<AssociatedCollectionPoint, Integer> {
+}

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -1,7 +1,13 @@
 package tqs.dropmate.dropmate_backend.services;
 
 import org.springframework.stereotype.Service;
+import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
+
+import java.util.List;
 
 @Service
 public class AdminService {
+    public List<AssociatedCollectionPoint> getAllACP(){
+        return null;
+    }
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -1,13 +1,18 @@
 package tqs.dropmate.dropmate_backend.services;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
+import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
 
 import java.util.List;
 
 @Service
 public class AdminService {
+    @Autowired
+    private AssociatedCollectionPointRepository acpRepository;
+
     public List<AssociatedCollectionPoint> getAllACP(){
-        return null;
+        return acpRepository.findAll();
     }
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/StoreService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/StoreService.java
@@ -1,7 +1,11 @@
 package tqs.dropmate.dropmate_backend.services;
 
 import org.springframework.stereotype.Service;
+import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
+
+import java.util.List;
 
 @Service
 public class StoreService {
+
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
@@ -8,9 +8,13 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import tqs.dropmate.dropmate_backend.controllers.AdminController;
 import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
+import tqs.dropmate.dropmate_backend.services.ACPService;
 import tqs.dropmate.dropmate_backend.services.AdminService;
+import tqs.dropmate.dropmate_backend.services.StoreService;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -20,13 +24,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest
+@WebMvcTest(controllers = AdminController.class)
 public class AdminController_withMockServiceTest {
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private AdminService adminService;
+    @MockBean
+    private ACPService acpService;
+    @MockBean
+    private StoreService storeService;
 
     private List<AssociatedCollectionPoint> allACP;
 
@@ -55,6 +63,7 @@ public class AdminController_withMockServiceTest {
         pickupPointThree.setTelephoneNumber("900000000");
 
         // Adding to ACP list
+        allACP = new ArrayList<>();
         allACP.add(pickupPointOne);
         allACP.add(pickupPointTwo);
         allACP.add(pickupPointThree);

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
@@ -1,33 +1,33 @@
-package tqs.dropmate.dropmate_backend.serviceTests;
+package tqs.dropmate.dropmate_backend.boundaryTests;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.internal.verification.VerificationModeFactory;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
-import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
 import tqs.dropmate.dropmate_backend.services.AdminService;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ExtendWith(MockitoExtension.class)
-public class ACPService_UnitTest {
+@WebMvcTest
+public class AdminController_withMockServiceTest {
+    @Autowired
+    private MockMvc mockMvc;
 
-    @Mock(lenient = true)
-    private AssociatedCollectionPointRepository acpRepository;
-
-    @InjectMocks
+    @MockBean
     private AdminService adminService;
 
-    // Expectations
     private List<AssociatedCollectionPoint> allACP;
 
     @BeforeEach
@@ -66,17 +66,14 @@ public class ACPService_UnitTest {
     }
 
     @Test
-    public void whenGetAllAcp_thenReturnAllAcp(){
-        // Set up Expectations
+    public void whenGetAllACP_thenReturn_statusOK() throws Exception {
         when(adminService.getAllACP()).thenReturn(allACP);
 
-        // Verify the result is as expected
-        List<AssociatedCollectionPoint> returnedACP = adminService.getAllACP();
-        assertThat(returnedACP).isEqualTo(allACP);
-        assertThat(returnedACP).hasSize(3);
-        assertThat(returnedACP).extracting(AssociatedCollectionPoint::getCity).contains("Aveiro", "Porto", "Viseu");
-
-        // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
-        Mockito.verify(adminService, VerificationModeFactory.times(1)).getAllACP();
+        mockMvc.perform(
+                        get("/dropmate/admin/acp").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)))
+                .andExpect(jsonPath("$[0].city", is("Aveiro")))
+                .andExpect(jsonPath("$[2].address", is("Fake address 3, Viseu")));
     }
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/DropMate_withMockServiceTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/DropMate_withMockServiceTest.java
@@ -1,7 +1,0 @@
-package tqs.dropmate.dropmate_backend.boundaryTests;
-
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-
-@WebMvcTest
-public class DropMate_withMockServiceTest {
-}

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -1,12 +1,63 @@
 package tqs.dropmate.dropmate_backend.integrationTests;
 
+import io.restassured.RestAssured;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
+import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.*;
+
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureTestDatabase
+@Testcontainers
+@TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DropMate_IntegrationTest {
+    private final static String BASE_URI = "http://api:";
+
+    @LocalServerPort
+    private int randomServerPort;
+
+    @Autowired
+    private AssociatedCollectionPointRepository acpRepository;
+
+    @Container
+    public static MySQLContainer container = new MySQLContainer("mysql:latest")
+            .withUsername("springuser")
+            .withPassword("password")
+            .withDatabaseName("DropMate");
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry){
+        registry.add("spring.datasource.url", container::getJdbcUrl);
+        registry.add("spring.datasource.password", container::getPassword);
+        registry.add("spring.datasource.username", container::getUsername);
+    }
+
+    @Test
+    public void whenGetAllACP_thenReturn_statusOK() throws Exception {
+        acpRepository.save(new AssociatedCollectionPoint("PickUpPointOne", "pickupone@mail.pt", "Aveiro", "Fake address 1, Aveiro", "953339994", 10 ));
+        acpRepository.save(new AssociatedCollectionPoint("PickUpPointTwo", "pickuptwo@mail.pt", "Porto", "Fake address 2, Porto", "935264901", 15 ));
+
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp")
+                .then().statusCode(200)
+                .body("size()", is(2)).and()
+                .body("name", hasItems("Aveiro", "Porto")).and()
+                .body("[1].email", is("pickuptwo@mail.pt"));
+
+    }
+
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -1,6 +1,7 @@
 package tqs.dropmate.dropmate_backend.integrationTests;
 
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -23,15 +24,17 @@ import static org.hamcrest.Matchers.*;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
 @TestPropertySource(properties = "spring.jpa.hibernate.ddl-auto=create")
+//@TestPropertySource(locations = "classpath:application-integrationtest.properties")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DropMate_IntegrationTest {
-    private final static String BASE_URI = "http://api:";
+    private final static String BASE_URI = "http://localhost:";
 
     @LocalServerPort
     private int randomServerPort;
 
     @Autowired
     private AssociatedCollectionPointRepository acpRepository;
+
 
     @Container
     public static MySQLContainer container = new MySQLContainer("mysql:latest")
@@ -46,16 +49,22 @@ public class DropMate_IntegrationTest {
         registry.add("spring.datasource.username", container::getUsername);
     }
 
+
+    @AfterEach
+    public void resetDB(){
+        acpRepository.deleteAll();
+    }
+
     @Test
     public void whenGetAllACP_thenReturn_statusOK() throws Exception {
-        acpRepository.save(new AssociatedCollectionPoint("PickUpPointOne", "pickupone@mail.pt", "Aveiro", "Fake address 1, Aveiro", "953339994", 10 ));
-        acpRepository.save(new AssociatedCollectionPoint("PickUpPointTwo", "pickuptwo@mail.pt", "Porto", "Fake address 2, Porto", "935264901", 15 ));
+        acpRepository.saveAndFlush(new AssociatedCollectionPoint("PickUpPointOne", "pickupone@mail.pt", "Aveiro", "Fake address 1, Aveiro", "953339994", 10 ));
+        acpRepository.saveAndFlush(new AssociatedCollectionPoint("PickUpPointTwo", "pickuptwo@mail.pt", "Porto", "Fake address 2, Porto", "935264901", 15 ));
 
         RestAssured.with().contentType("application/json")
                 .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp")
                 .then().statusCode(200)
                 .body("size()", is(2)).and()
-                .body("name", hasItems("Aveiro", "Porto")).and()
+                .body("city", hasItems("Aveiro", "Porto")).and()
                 .body("[1].email", is("pickuptwo@mail.pt"));
 
     }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/ACPService_UnitTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/ACPService_UnitTest.java
@@ -1,84 +1,11 @@
 package tqs.dropmate.dropmate_backend.serviceTests;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.internal.verification.VerificationModeFactory;
+
 import org.mockito.junit.jupiter.MockitoExtension;
-import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
-import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
-import tqs.dropmate.dropmate_backend.services.AdminService;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class ACPService_UnitTest {
 
-    @Mock(lenient = true)
-    private AssociatedCollectionPointRepository acpRepository;
-
-    @InjectMocks
-    private AdminService adminService;
-
-    // Expectations
-    private List<AssociatedCollectionPoint> allACP;
-
-    @BeforeEach
-    public void setUp(){
-        // Creating test pickup points
-        AssociatedCollectionPoint pickupPointOne = new AssociatedCollectionPoint();
-        pickupPointOne.setCity("Aveiro");
-        pickupPointOne.setAddress("Fake address 1, Aveiro");
-        pickupPointOne.setEmail("pickupone@mail.pt");
-        pickupPointOne.setDeliveryLimit(10);
-        pickupPointOne.setTelephoneNumber("953339994");
-
-        AssociatedCollectionPoint pickupPointTwo = new AssociatedCollectionPoint();
-        pickupPointTwo.setCity("Porto");
-        pickupPointTwo.setAddress("Fake address 2, Porto");
-        pickupPointTwo.setEmail("pickuptwo@mail.pt");
-        pickupPointTwo.setDeliveryLimit(15);
-        pickupPointTwo.setTelephoneNumber("939333594");
-
-        AssociatedCollectionPoint pickupPointThree = new AssociatedCollectionPoint();
-        pickupPointThree.setCity("Viseu");
-        pickupPointThree.setAddress("Fake address 3, Viseu");
-        pickupPointThree.setEmail("pickupthree@mail.pt");
-        pickupPointThree.setDeliveryLimit(12);
-        pickupPointThree.setTelephoneNumber("900000000");
-
-        // Adding to ACP list
-        allACP = new ArrayList<>();
-        allACP.add(pickupPointOne);
-        allACP.add(pickupPointTwo);
-        allACP.add(pickupPointThree);
-    }
-
-    @AfterEach
-    public void tearDown(){
-        allACP = null;
-    }
-
-    @Test
-    public void whenGetAllAcp_thenReturnAllAcp(){
-        // Set up Expectations
-        when(adminService.getAllACP()).thenReturn(allACP);
-
-        // Verify the result is as expected
-        List<AssociatedCollectionPoint> returnedACP = adminService.getAllACP();
-        assertThat(returnedACP).isEqualTo(allACP);
-        assertThat(returnedACP).hasSize(3);
-        assertThat(returnedACP).extracting(AssociatedCollectionPoint::getCity).contains("Aveiro", "Porto", "Viseu");
-
-        // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
-        Mockito.verify(acpRepository, VerificationModeFactory.times(1)).findAll();
-    }
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/ACPService_UnitTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/ACPService_UnitTest.java
@@ -13,6 +13,7 @@ import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
 import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
 import tqs.dropmate.dropmate_backend.services.AdminService;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +56,7 @@ public class ACPService_UnitTest {
         pickupPointThree.setTelephoneNumber("900000000");
 
         // Adding to ACP list
+        allACP = new ArrayList<>();
         allACP.add(pickupPointOne);
         allACP.add(pickupPointTwo);
         allACP.add(pickupPointThree);
@@ -77,6 +79,6 @@ public class ACPService_UnitTest {
         assertThat(returnedACP).extracting(AssociatedCollectionPoint::getCity).contains("Aveiro", "Porto", "Viseu");
 
         // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
-        Mockito.verify(adminService, VerificationModeFactory.times(1)).getAllACP();
+        Mockito.verify(acpRepository, VerificationModeFactory.times(1)).findAll();
     }
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
@@ -1,8 +1,83 @@
 package tqs.dropmate.dropmate_backend.serviceTests;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
+import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
+import tqs.dropmate.dropmate_backend.services.AdminService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class AdminService_UnitTest {
+    @Mock(lenient = true)
+    private AssociatedCollectionPointRepository acpRepository;
+
+    @InjectMocks
+    private AdminService adminService;
+
+    // Expectations
+    private List<AssociatedCollectionPoint> allACP;
+
+    @BeforeEach
+    public void setUp(){
+        // Creating test pickup points
+        AssociatedCollectionPoint pickupPointOne = new AssociatedCollectionPoint();
+        pickupPointOne.setCity("Aveiro");
+        pickupPointOne.setAddress("Fake address 1, Aveiro");
+        pickupPointOne.setEmail("pickupone@mail.pt");
+        pickupPointOne.setDeliveryLimit(10);
+        pickupPointOne.setTelephoneNumber("953339994");
+
+        AssociatedCollectionPoint pickupPointTwo = new AssociatedCollectionPoint();
+        pickupPointTwo.setCity("Porto");
+        pickupPointTwo.setAddress("Fake address 2, Porto");
+        pickupPointTwo.setEmail("pickuptwo@mail.pt");
+        pickupPointTwo.setDeliveryLimit(15);
+        pickupPointTwo.setTelephoneNumber("939333594");
+
+        AssociatedCollectionPoint pickupPointThree = new AssociatedCollectionPoint();
+        pickupPointThree.setCity("Viseu");
+        pickupPointThree.setAddress("Fake address 3, Viseu");
+        pickupPointThree.setEmail("pickupthree@mail.pt");
+        pickupPointThree.setDeliveryLimit(12);
+        pickupPointThree.setTelephoneNumber("900000000");
+
+        // Adding to ACP list
+        allACP = new ArrayList<>();
+        allACP.add(pickupPointOne);
+        allACP.add(pickupPointTwo);
+        allACP.add(pickupPointThree);
+    }
+
+    @AfterEach
+    public void tearDown(){
+        allACP = null;
+    }
+
+    @Test
+    public void whenGetAllAcp_thenReturnAllAcp(){
+        // Set up Expectations
+        when(adminService.getAllACP()).thenReturn(allACP);
+
+        // Verify the result is as expected
+        List<AssociatedCollectionPoint> returnedACP = adminService.getAllACP();
+        assertThat(returnedACP).isEqualTo(allACP);
+        assertThat(returnedACP).hasSize(3);
+        assertThat(returnedACP).extracting(AssociatedCollectionPoint::getCity).contains("Aveiro", "Porto", "Viseu");
+
+        // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
+        Mockito.verify(acpRepository, VerificationModeFactory.times(1)).findAll();
+    }
 }

--- a/DropMate_Backend/src/test/resources/application-integrationtest.properties
+++ b/DropMate_Backend/src/test/resources/application-integrationtest.properties
@@ -1,0 +1,5 @@
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.url=jdbc:mysql://localhost:3306/testDatabase?allowPublicKeyRetrieval=true&useSSL=false
+spring.datasource.username=springuser
+spring.datasource.password=password
+spring.jackson.serialization.fail-on-empty-beans=false


### PR DESCRIPTION
User Story: Admin Browses the List of ACPs
Jira Code: DM-19

Changes made:

- Completed the GET "dropmate/admin/acp" API endpoint on Admin Controller.
- Completed the getAllACP() function on Admin Service.

Tests created:

- Admin Service Unit Test: Added the whenGetAllAcp_thenReturnAllAcp() test.
- Integration Test: Added the whenGetAllACP_thenReturn_statusOK() test.
- Admin controller boundary test: Added the whenGetAllACP_thenReturn_statusOK() test.