### PR TITLE
DM-27: Admin Checks the Shipment Statistics for a Specific ACP

### DIFF
--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -3,6 +3,7 @@ package tqs.dropmate.dropmate_backend.controllers;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tqs.dropmate.dropmate_backend.datamodel.*;
+import tqs.dropmate.dropmate_backend.exceptions.ResourceNotFoundException;
 import tqs.dropmate.dropmate_backend.services.AdminService;
 import tqs.dropmate.dropmate_backend.utils.SuccessfulRequest;
 
@@ -74,8 +75,8 @@ public class AdminController {
 
     /** This method returns the statistics associated with a specific ACP */
     @GetMapping("/acp/{acpID}/statistics")
-    public ResponseEntity<Map<String, String>> getACPStatistics(@PathVariable(name = "acpID") Long acpID){
-        return null;
+    public ResponseEntity<Map<String, Integer>> getACPStatistics(@PathVariable(name = "acpID") Integer acpID) throws ResourceNotFoundException {
+        return ResponseEntity.ok().body(adminService.getSpecificACPStatistics(acpID));
     }
 
     /** This method returns all the parcels waiting for delivery */

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
 import tqs.dropmate.dropmate_backend.datamodel.Parcel;
 import tqs.dropmate.dropmate_backend.datamodel.Status;
+import tqs.dropmate.dropmate_backend.exceptions.ResourceNotFoundException;
 import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
 import tqs.dropmate.dropmate_backend.repositories.ParcelRepository;
 
@@ -51,5 +52,14 @@ public class AdminService {
                             return statistics;
                         }
                 ));
+    }
+
+    public Map<String, Integer> getSpecificACPStatistics(Integer acpID) throws ResourceNotFoundException {
+        AssociatedCollectionPoint acp = acpRepository.findById(acpID).orElseThrow(() -> new ResourceNotFoundException("Couldn't find ACP with the ID " + acpID + "!"));
+
+        Map<String, Integer> stats = acp.getOperationalStatistics();
+        stats.put("deliveryLimit", acp.getDeliveryLimit());
+
+        return stats;
     }
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -92,6 +92,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    @Order(3)
     public void whenGetAllACP_thenReturn_statusOK() throws Exception {
         RestAssured.with().contentType("application/json")
                 .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp")
@@ -103,6 +104,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    @Order(4)
     public void whenGetAllAParcelsWaitDelivery_thenReturn_statusOK() throws Exception {
         parcelRepository.saveAndFlush(new Parcel("DEL123", "PCK123", 1.5, null, null, Status.IN_DELIVERY, testACP, testStore));
         parcelRepository.saveAndFlush(new Parcel("DEL456", "PCK456", 3.2, null, null, Status.IN_DELIVERY, testACP, testStore));
@@ -120,6 +122,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    @Order(5)
     public void whenGetAllAParcelsWaitPickup_thenReturn_statusOK() throws Exception {
         parcelRepository.saveAndFlush(new Parcel("DEL123", "PCK123", 1.5, null, null, Status.IN_DELIVERY, testACP, testStore));
         parcelRepository.saveAndFlush(new Parcel("DEL456", "PCK456", 3.2, null, null, Status.IN_DELIVERY, testACP, testStore));
@@ -137,6 +140,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    @Order(6)
     public void whenGetAllACPOperationalStatistics_thenReturn_statusOK() throws Exception {
         // Doing the test
         io.restassured.path.json.JsonPath path  = RestAssured.with().contentType("application/json")
@@ -155,8 +159,9 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    @Order(1)
     public void whenGetSpecificOperationStatistics_withValidID_thenReturn_statusOK() {
-        RestAssured.with().contentType("application/json")
+             RestAssured.with().contentType("application/json")
                 .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/1/statistics")
                 .then().statusCode(200)
                 .body("total_parcels", is(10)).and()
@@ -166,6 +171,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    @Order(2)
     public void whenGetSpecificOperationStatistics_withInvalidID_thenReturn_statusOK() {
         RestAssured.with().contentType("application/json")
                 .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/-21/statistics")

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -165,4 +165,11 @@ public class DropMate_IntegrationTest {
                 .body("deliveryLimit", is(10));
     }
 
+    @Test
+    public void whenGetSpecificOperationStatistics_withInvalidID_thenReturn_statusOK() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/-21/statistics")
+                .then().statusCode(404);
+    }
+
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -120,6 +120,23 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    public void whenGetAllAParcelsWaitPickup_thenReturn_statusOK() throws Exception {
+        parcelRepository.saveAndFlush(new Parcel("DEL123", "PCK123", 1.5, null, null, Status.IN_DELIVERY, testACP, testStore));
+        parcelRepository.saveAndFlush(new Parcel("DEL456", "PCK456", 3.2, null, null, Status.IN_DELIVERY, testACP, testStore));
+        parcelRepository.saveAndFlush(new Parcel("DEL790", "PCK356", 1.5, new Date(2023, 5, 22), null, Status.WAITING_FOR_PICKUP, testACP, testStore));
+        parcelRepository.saveAndFlush(new Parcel("DEL367", "PCK803", 2.2, new Date(2023, 5, 22), null, Status.WAITING_FOR_PICKUP, testACP, testStore));
+        parcelRepository.saveAndFlush(new Parcel("DEL000", "PCK257", 1.5, new Date(2023, 5, 22), new Date(2023, 5, 28), Status.DELIVERED, testACP, testStore));
+        parcelRepository.saveAndFlush(new Parcel("DEL843", "PCK497", 1.6, new Date(2023, 5, 22), new Date(2023, 5, 29), Status.DELIVERED, testACP, testStore));
+
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/parcels/all/pickup")
+                .then().statusCode(200)
+                .body("size()", is(2)).and()
+                .body("parcelStatus", hasItems(Status.WAITING_FOR_PICKUP.toString())).and()
+                .body("pickupCode", hasItems("PCK356", "PCK803"));
+    }
+
+    @Test
     public void whenGetAllACPOperationalStatistics_thenReturn_statusOK() throws Exception {
         // Doing the test
         io.restassured.path.json.JsonPath path  = RestAssured.with().contentType("application/json")
@@ -137,19 +154,15 @@ public class DropMate_IntegrationTest {
         }
     }
 
-    public void whenGetAllAParcelsWaitPickup_thenReturn_statusOK() throws Exception {
-        parcelRepository.saveAndFlush(new Parcel("DEL123", "PCK123", 1.5, null, null, Status.IN_DELIVERY, testACP, testStore));
-        parcelRepository.saveAndFlush(new Parcel("DEL456", "PCK456", 3.2, null, null, Status.IN_DELIVERY, testACP, testStore));
-        parcelRepository.saveAndFlush(new Parcel("DEL790", "PCK356", 1.5, new Date(2023, 5, 22), null, Status.WAITING_FOR_PICKUP, testACP, testStore));
-        parcelRepository.saveAndFlush(new Parcel("DEL367", "PCK803", 2.2, new Date(2023, 5, 22), null, Status.WAITING_FOR_PICKUP, testACP, testStore));
-        parcelRepository.saveAndFlush(new Parcel("DEL000", "PCK257", 1.5, new Date(2023, 5, 22), new Date(2023, 5, 28), Status.DELIVERED, testACP, testStore));
-        parcelRepository.saveAndFlush(new Parcel("DEL843", "PCK497", 1.6, new Date(2023, 5, 22), new Date(2023, 5, 29), Status.DELIVERED, testACP, testStore));
-
+    @Test
+    public void whenGetSpecificOperationStatistics_withValidID_thenReturn_statusOK() {
         RestAssured.with().contentType("application/json")
-                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/parcels/all/pickup")
+                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/1/statistics")
                 .then().statusCode(200)
-                .body("size()", is(2)).and()
-                .body("parcelStatus", hasItems(Status.WAITING_FOR_PICKUP.toString())).and()
-                .body("pickupCode", hasItems("PCK356", "PCK803"));
+                .body("total_parcels", is(10)).and()
+                .body("parcels_waiting_pickup", is(3)).and()
+                .body("parcels_in_delivery", is(5)).and()
+                .body("deliveryLimit", is(10));
     }
+
 }


### PR DESCRIPTION
User Story: Admin Checks the Shipment Statistics for a Specific ACP
Jira Code: DM-26

Changes made:

- Completed the GET "/acp/{acpID}/statistics" API endpoint on Admin Controller.
- Completed the getSpecificACPStatistics() function on Admin Service.

Tests created:

- Admin Service Unit Test: Added the whenGetSpecificOperationalStatisics_withValidACP_thenReturnOnlySpecificACP() and  whenGetSpecificOperationalStatisics_withInvalidACP_thenReturnOnlySpecificACP() tests.
- Integration Test: Added the whenGetSpecificOperationStatistics_withValidID_thenReturn_statusOK() and whenGetSpecificOperationStatistics_withInvalidID_thenReturn_statusOK() tests.
- Admin controller boundary test: Added the whenGetSpecificACPOperationalStatistics_withValidID_thenReturn_statusOK() and whenGetSpecificACPOperationalStatistics_withInvalidID_thenReturn_statusOK() tests.