### PR TITLE
DM-20: Admin Checks the Details of a Specific ACP

### DIFF
--- a/DropMate_Backend/pom.xml
+++ b/DropMate_Backend/pom.xml
@@ -72,6 +72,11 @@
 			<artifactId>spring-mock-mvc</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -94,16 +94,14 @@ public class AdminController {
 
     /** This method returns all the parcels waiting for delivery at a specific ACP */
     @GetMapping("/parcels/{acpID}/delivery")
-    public ResponseEntity<List<Parcel>> getAllParcelsWaitingDeliveryAtACP(@PathVariable(name = "acpID") Integer acpID){
-        //return ResponseEntity.ok().body(adminService.getParcelsWaitingDeliveryAtACP(acpID));
-        return null;
+    public ResponseEntity<List<Parcel>> getAllParcelsWaitingDeliveryAtACP(@PathVariable(name = "acpID") Integer acpID) throws ResourceNotFoundException {
+        return ResponseEntity.ok().body(adminService.getParcelsWaitingDeliveryAtACP(acpID));
     }
 
     /** This method returns all the parcels waiting for pickup at a specific ACP */
     @GetMapping("/parcels/{acpID}/pickup")
-    public ResponseEntity<List<Parcel>> getAllParcelsWaitingPickupAtACP(@PathVariable(name = "acpID") Integer acpID){
-        //return ResponseEntity.ok().body(adminService.getParcelsWaitingPickupAtACP(acpID));
-        return null;
+    public ResponseEntity<List<Parcel>> getAllParcelsWaitingPickupAtACP(@PathVariable(name = "acpID") Integer acpID) throws ResourceNotFoundException {
+        return ResponseEntity.ok().body(adminService.getParcelsWaitingPickupAtACP(acpID));
     }
 
     /** Returns all the Operators associated with each ACP */

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -46,18 +46,19 @@ public class AdminController {
                                                        @RequestParam(name = "telephone", required = false) String telephone,
                                                        @RequestParam(name = "city", required = false) String city,
                                                        @RequestParam(name = "address", required = false) String address){
+        //return ResponseEntity.ok().body(adminService.updateACPDetails(email, name, telephone, city, address));
         return null;
     }
 
     /** This method returns the details associated with a specific ACP */
     @GetMapping("/acp/{acpID}")
-    public ResponseEntity<AssociatedCollectionPoint> getACPDetails(@PathVariable(name = "acpID") Long acpID){
-        return null;
+    public ResponseEntity<AssociatedCollectionPoint> getACPDetails(@PathVariable(name = "acpID") Integer acpID) throws ResourceNotFoundException {
+        return ResponseEntity.ok().body(adminService.getACPDetails(acpID));
     }
 
     /** Deletes an ACP */
     @DeleteMapping ("/acp/{acpID}")
-    public ResponseEntity<SuccessfulRequest> deleteACP(@PathVariable(name = "acpID") Long acpID){
+    public ResponseEntity<SuccessfulRequest> deleteACP(@PathVariable(name = "acpID") Integer acpID){
         return null;
     }
 
@@ -93,13 +94,15 @@ public class AdminController {
 
     /** This method returns all the parcels waiting for delivery at a specific ACP */
     @GetMapping("/parcels/{acpID}/delivery")
-    public ResponseEntity<List<Parcel>> getAllParcelsWaitingDeliveryAtACP(@PathVariable(name = "acpID") Long acpID){
+    public ResponseEntity<List<Parcel>> getAllParcelsWaitingDeliveryAtACP(@PathVariable(name = "acpID") Integer acpID){
+        //return ResponseEntity.ok().body(adminService.getParcelsWaitingDeliveryAtACP(acpID));
         return null;
     }
 
     /** This method returns all the parcels waiting for pickup at a specific ACP */
     @GetMapping("/parcels/{acpID}/pickup")
-    public ResponseEntity<List<Parcel>> getAllParcelsWaitingPickupAtACP(@PathVariable(name = "acpID") Long acpID){
+    public ResponseEntity<List<Parcel>> getAllParcelsWaitingPickupAtACP(@PathVariable(name = "acpID") Integer acpID){
+        //return ResponseEntity.ok().body(adminService.getParcelsWaitingPickupAtACP(acpID));
         return null;
     }
 

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -40,14 +40,14 @@ public class AdminController {
     }
 
     /** Updates the details of an ACP */
-    @PutMapping("/acp")
-    public ResponseEntity<SuccessfulRequest> updateACP(@RequestParam(name = "email", required = false) String email,
+    @PutMapping("/acp/{acpID}")
+    public ResponseEntity<AssociatedCollectionPoint> updateACP(@PathVariable(name = "acpID") Integer acpID,
+                                                       @RequestParam(name = "email", required = false) String email,
                                                        @RequestParam(name = "name", required = false) String name,
                                                        @RequestParam(name = "telephone", required = false) String telephone,
                                                        @RequestParam(name = "city", required = false) String city,
-                                                       @RequestParam(name = "address", required = false) String address){
-        //return ResponseEntity.ok().body(adminService.updateACPDetails(email, name, telephone, city, address));
-        return null;
+                                                       @RequestParam(name = "address", required = false) String address) throws ResourceNotFoundException {
+        return ResponseEntity.ok().body(adminService.updateACPDetails(acpID, email, name, telephone, city, address));
     }
 
     /** This method returns the details associated with a specific ACP */

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/datamodel/Parcel.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/datamodel/Parcel.java
@@ -36,6 +36,18 @@ public class Parcel {
     @Convert(converter = StatusConverter.class)
     private Status parcelStatus;
 
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name ="acpId", nullable = false)
+    @ToString.Exclude
+    private AssociatedCollectionPoint pickupACP;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name ="storeId", nullable = false)
+    @ToString.Exclude
+    private Store store;
+
     public Parcel(String deliveryCode, String pickupCode, Double weight, Date deliveryDate, Date pickupDate, Status parcelStatus) {
         this.deliveryCode = deliveryCode;
         this.pickupCode = pickupCode;
@@ -55,16 +67,4 @@ public class Parcel {
         this.pickupACP = pickupACP;
         this.store = store;
     }
-
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name ="acpId", nullable = false)
-    @ToString.Exclude
-    private AssociatedCollectionPoint pickupACP;
-
-    @JsonIgnore
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name ="storeId", nullable = false)
-    @ToString.Exclude
-    private Store store;
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -8,6 +8,7 @@ import tqs.dropmate.dropmate_backend.datamodel.Status;
 import tqs.dropmate.dropmate_backend.exceptions.ResourceNotFoundException;
 import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
 import tqs.dropmate.dropmate_backend.repositories.ParcelRepository;
+import tqs.dropmate.dropmate_backend.utils.SuccessfulRequest;
 
 import java.util.HashMap;
 import java.util.List;
@@ -108,6 +109,32 @@ public class AdminService {
     public AssociatedCollectionPoint getACPDetails(Integer acpID) throws ResourceNotFoundException {
         return this.getACPFromID(acpID);
     }
+
+    /** Updates the details of an ACP
+     * @param acpID - ID of the ACP in the database
+     * @param email - Updated email for the ACP. Could be null
+     * @param name - Updated name for the ACP. Could be null
+     * @param telephone - Updated telephone for the ACP. Could be null
+     * @param city - Updated city for the ACP. Could be null
+     * @param address - Updated address for the ACP. Could be null
+     * @return a message stating the Request was Succesful
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
+    public AssociatedCollectionPoint updateACPDetails(Integer acpID, String email, String name, String telephone, String city, String address) throws ResourceNotFoundException {
+        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
+
+        acp.setName(name != null ? name : acp.getName());
+        acp.setEmail(email != null ? email : acp.getEmail());
+        acp.setTelephoneNumber(telephone != null ? telephone : acp.getTelephoneNumber());
+        acp.setCity(city != null ? city : acp.getCity());
+        acp.setAddress(address != null ? address : acp.getAddress());
+
+        acpRepository.save(acp);
+
+        return acp;
+    }
+
+
 
     // Auxilliary functions
 

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -62,4 +62,9 @@ public class AdminService {
 
         return stats;
     }
+
+    /** This method returns the details associated with a specific ACP */
+    public AssociatedCollectionPoint getACPDetails(Integer acpID) throws ResourceNotFoundException {
+        return acpRepository.findById(acpID).orElseThrow(() -> new ResourceNotFoundException("Couldn't find ACP with the ID " + acpID + "!"));
+    }
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -26,21 +26,53 @@ public class AdminService {
         return acpRepository.findAll();
     }
 
-    /** This method returns all the parcels waiting for delivery */
+    /** This method returns all the parcels waiting for delivery
+     * @return List of all parcels waiting delivery */
     public List<Parcel> getAllParcelsWaitingDelivery(){
         return parcelRepository.findAll().stream()
                 .filter(parcel -> parcel.getParcelStatus().equals(Status.IN_DELIVERY))
                 .collect(Collectors.toList());
     }
   
-    /** This method returns all the parcels waiting for pickup */
+    /** This method returns all the parcels waiting for pickup
+     * @return List of all the parcels waiting for pickup.*/
     public List<Parcel> getAllParcelsWaitingPickup(){
         return parcelRepository.findAll().stream()
                 .filter(parcel -> parcel.getParcelStatus().equals(Status.WAITING_FOR_PICKUP))
                 .collect(Collectors.toList());
     }
 
-    /** This method returns all the operational statistics of all ACP's */
+    /** This method returns all the parcels waiting for delivery at a specific ACP
+     * @param acpID - ID of the ACP in the database
+     * @return List of the parcels waiting delivery at the corresponding ACP
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
+    public List<Parcel> getParcelsWaitingDeliveryAtACP(Integer acpID) throws ResourceNotFoundException {
+        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
+
+        return parcelRepository.findAll().stream()
+                .filter(parcel -> parcel.getParcelStatus().equals(Status.IN_DELIVERY))
+                .filter(parcel -> parcel.getPickupACP().equals(acp))
+                .collect(Collectors.toList());
+    }
+
+    /** This method returns all the parcels waiting for pickup at a specific ACP
+     * @param acpID - ID of the ACP in the database
+     * @return List of the parcels waiting pickup at the corresponding ACP
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
+    public List<Parcel> getParcelsWaitingPickupAtACP(Integer acpID) throws ResourceNotFoundException {
+        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
+
+        return parcelRepository.findAll().stream()
+                .filter(parcel -> parcel.getParcelStatus().equals(Status.WAITING_FOR_PICKUP))
+                .filter(parcel -> parcel.getPickupACP().equals(acp))
+                .collect(Collectors.toList());
+    }
+
+    /** This method returns all the operational statistics of all ACP's
+     * @return Map containing the operational statistics for each ACP. Each key is a ACP, and the value another Map of the corresponding statistics.
+     * */
     public Map<AssociatedCollectionPoint, Map<String, Integer>> getAllACPStatistics() {
         return acpRepository.findAll().stream()
                 .collect(Collectors.toMap(
@@ -54,8 +86,13 @@ public class AdminService {
                 ));
     }
 
+    /** This method returns the details associated with a specific ACP
+     * @param acpID - ID of the ACP in the database
+     * @return Map containing the operational statistics of the ACP. Each key is a parameter, with the value being the related statistic.
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
     public Map<String, Integer> getSpecificACPStatistics(Integer acpID) throws ResourceNotFoundException {
-        AssociatedCollectionPoint acp = acpRepository.findById(acpID).orElseThrow(() -> new ResourceNotFoundException("Couldn't find ACP with the ID " + acpID + "!"));
+        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
 
         Map<String, Integer> stats = acp.getOperationalStatistics();
         stats.put("deliveryLimit", acp.getDeliveryLimit());
@@ -63,8 +100,24 @@ public class AdminService {
         return stats;
     }
 
-    /** This method returns the details associated with a specific ACP */
+    /** This method returns the details associated with a specific ACP
+     * @param acpID - ID of the ACP in the database
+     * @return corresponding ACP details
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
     public AssociatedCollectionPoint getACPDetails(Integer acpID) throws ResourceNotFoundException {
+        return this.getACPFromID(acpID);
+    }
+
+    // Auxilliary functions
+
+    /** This method checks whether an ACP exists or not on the ACPRepository, based on its ID. If it doesn't it throws
+     * an exception.
+     * @param acpID - ID of the ACP in the database
+     * @return corresponding ACP
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     */
+    private AssociatedCollectionPoint getACPFromID(Integer acpID) throws ResourceNotFoundException {
         return acpRepository.findById(acpID).orElseThrow(() -> new ResourceNotFoundException("Couldn't find ACP with the ID " + acpID + "!"));
     }
 }

--- a/DropMate_Backend/src/main/resources/application.properties
+++ b/DropMate_Backend/src/main/resources/application.properties
@@ -1,9 +1,12 @@
 spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url=jdbc:mysql://database:3306/DropMate?allowPublicKeyRetrieval=true&useSSL=false
+#spring.datasource.url=jdbc:mysql://database:3306/DropMate?allowPublicKeyRetrieval=true&useSSL=false
 spring.datasource.username=springuser
 spring.datasource.password=password
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQLDialect
 spring.jpa.show-sql=true
+
+# Local
+spring.datasource.url=jdbc:mysql://localhost:3306/DropMate?allowPublicKeyRetrieval=true&useSSL=false
 

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
@@ -2,7 +2,6 @@ package tqs.dropmate.dropmate_backend.boundaryTests;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -186,6 +185,27 @@ public class AdminController_withMockServiceTest {
 
         mockMvc.perform(
                         get("/dropmate/admin/acp/-2/statistics").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void whenGetSpecificACPDetails_withValidID_thenReturn_statusOK() throws Exception {
+        when(adminService.getACPDetails(2)).thenReturn(allACP.get(1));
+
+        mockMvc.perform(
+                        get("/dropmate/admin/acp/2").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.city", is("Porto")))
+                .andExpect(jsonPath("$.address", is("Fake address 2, Porto")))
+                .andExpect(jsonPath("$.deliveryLimit", is(15)));
+    }
+
+    @Test
+    public void whenGetSpecificACPDetails_withInvalidID_thenReturn_statusOK() throws Exception {
+        when(adminService.getACPDetails(-2)).thenThrow(new ResourceNotFoundException("Couldn't find ACP with the ID -2!"));
+
+        mockMvc.perform(
+                        get("/dropmate/admin/acp/-2").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
     }
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
@@ -40,18 +40,20 @@ public class AdminController_withMockServiceTest {
     private List<AssociatedCollectionPoint> allACP;
     private List<Parcel> parcelsWaitingDelivery;
     private List<Parcel> parcelsWaitingPickup;
+    private AssociatedCollectionPoint pickupPointOne;
+    private AssociatedCollectionPoint pickupPointTwo;
 
     @BeforeEach
     public void setUp(){
         // Creating test pickup points
-        AssociatedCollectionPoint pickupPointOne = new AssociatedCollectionPoint();
+        pickupPointOne = new AssociatedCollectionPoint();
         pickupPointOne.setCity("Aveiro");
         pickupPointOne.setAddress("Fake address 1, Aveiro");
         pickupPointOne.setEmail("pickupone@mail.pt");
         pickupPointOne.setDeliveryLimit(10);
         pickupPointOne.setTelephoneNumber("953339994");
 
-        AssociatedCollectionPoint pickupPointTwo = new AssociatedCollectionPoint();
+        pickupPointTwo = new AssociatedCollectionPoint();
         pickupPointTwo.setCity("Porto");
         pickupPointTwo.setAddress("Fake address 2, Porto");
         pickupPointTwo.setEmail("pickuptwo@mail.pt");
@@ -91,6 +93,7 @@ public class AdminController_withMockServiceTest {
     public void tearDown(){
         allACP = null;
         parcelsWaitingDelivery = null;
+        parcelsWaitingPickup = null;
     }
 
     @Test
@@ -128,6 +131,49 @@ public class AdminController_withMockServiceTest {
                 .andExpect(jsonPath("$[0].deliveryCode", is("DEL790")))
                 .andExpect(jsonPath("$[1].parcelStatus", is(Status.WAITING_FOR_PICKUP.toString())))
                 .andExpect(jsonPath("$[1].pickupCode", is("PCK803")));
+    }
+
+    @Test
+    public void whenGetParcelsWaitingDelivery_atSpecificACP_withValidID_thenReturn_StatusOK() throws Exception {
+        when(adminService.getParcelsWaitingDeliveryAtACP(0)).thenReturn(parcelsWaitingDelivery);
+
+        mockMvc.perform(
+                        get("/dropmate/admin/parcels/0/delivery").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].deliveryCode", is("DEL123")))
+                .andExpect(jsonPath("$[1].parcelStatus", is(Status.IN_DELIVERY.toString())));
+    }
+
+    @Test
+    public void whenGetParcelsWaitingPickup_atSpecificACP_withValidID_thenReturn_StatusOK() throws Exception {
+            when(adminService.getParcelsWaitingPickupAtACP(0)).thenReturn(parcelsWaitingPickup);
+
+            mockMvc.perform(
+                            get("/dropmate/admin/parcels/0/pickup").contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(2)))
+                    .andExpect(jsonPath("$[0].deliveryCode", is("DEL790")))
+                    .andExpect(jsonPath("$[1].parcelStatus", is(Status.WAITING_FOR_PICKUP.toString())))
+                    .andExpect(jsonPath("$[1].pickupCode", is("PCK803")));
+    }
+
+    @Test
+    public void whenGetParcelsWaitingDelivery_atSpecificACP_withInvalidID_thenReturn_statusNotFound() throws Exception {
+        when(adminService.getParcelsWaitingDeliveryAtACP(-2)).thenThrow(new ResourceNotFoundException("Couldn't find ACP with the ID -2!"));
+
+        mockMvc.perform(
+                        get("/dropmate/admin/parcels/-2/delivery").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void whenGetParcelsWaitingPickup_atSpecificACP_withInvalidID_thenReturn_statusNotFound() throws Exception {
+        when(adminService.getParcelsWaitingPickupAtACP(-2)).thenThrow(new ResourceNotFoundException("Couldn't find ACP with the ID -2!"));
+
+        mockMvc.perform(
+                        get("/dropmate/admin/parcels/-2/pickup").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -180,7 +226,7 @@ public class AdminController_withMockServiceTest {
     }
 
     @Test
-    public void whenGetSpecificACPOperationalStatistics_withInvalidID_thenReturn_statusOK() throws Exception {
+    public void whenGetSpecificACPOperationalStatistics_withInvalidID_thenReturn_statusNotFound() throws Exception {
         when(adminService.getSpecificACPStatistics(-2)).thenThrow(new ResourceNotFoundException("Couldn't find ACP with the ID -2!"));
 
         mockMvc.perform(
@@ -201,7 +247,7 @@ public class AdminController_withMockServiceTest {
     }
 
     @Test
-    public void whenGetSpecificACPDetails_withInvalidID_thenReturn_statusOK() throws Exception {
+    public void whenGetSpecificACPDetails_withInvalidID_thenReturn_statusNotFound() throws Exception {
         when(adminService.getACPDetails(-2)).thenThrow(new ResourceNotFoundException("Couldn't find ACP with the ID -2!"));
 
         mockMvc.perform(

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
@@ -26,6 +26,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -252,6 +254,70 @@ public class AdminController_withMockServiceTest {
 
         mockMvc.perform(
                         get("/dropmate/admin/acp/-2").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void whenUpdateACPDetails_withValidID_allFields_thenReturn_statusOK() throws Exception {
+        // Preparing for the test
+        pickupPointTwo.setName("test");
+        pickupPointTwo.setEmail("newemail@mail.pt");
+        pickupPointTwo.setAddress("Nevermore");
+        pickupPointTwo.setCity("Lalaland");
+        pickupPointTwo.setTelephoneNumber("000000000");
+
+        // Setting up expectations
+        when(adminService.updateACPDetails(2, "newemail@mail.pt", "test", "000000000", "Lalaland", "Nevermore"))
+                .thenReturn(pickupPointTwo);
+
+
+        // Performing the call
+        mockMvc.perform(
+                        put("/dropmate/admin/acp/2").contentType(MediaType.APPLICATION_JSON)
+                                .param("name", "test")
+                                .param("email", "newemail@mail.pt")
+                                .param("telephone", "000000000")
+                                .param("city", "Lalaland")
+                                .param("address", "Nevermore"))
+                .andExpect(status().isOk()).andDo(print())
+                .andExpect(jsonPath("$.city", is("Lalaland")))
+                .andExpect(jsonPath("$.address", is("Nevermore")))
+                .andExpect(jsonPath("$.email", is("newemail@mail.pt")))
+                .andExpect(jsonPath("$.deliveryLimit", is(15)));
+    }
+
+    @Test
+    public void whenUpdateACPDetails_withValidID_somFields_thenReturn_statusOK() throws Exception {
+        // Preparing for the test
+        pickupPointTwo.setAddress("Nevermore");
+        pickupPointTwo.setCity("Lalaland");
+
+        // Setting up expectations
+        when(adminService.updateACPDetails(2, null, null, null, "Lalaland", "Nevermore"))
+                .thenReturn(pickupPointTwo);
+
+
+        mockMvc.perform(
+                        put("/dropmate/admin/acp/2").contentType(MediaType.APPLICATION_JSON)
+                                .param("city", "Lalaland")
+                                .param("address", "Nevermore"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.city", is("Lalaland")))
+                .andExpect(jsonPath("$.address", is("Nevermore")))
+                .andExpect(jsonPath("$.email", is("pickuptwo@mail.pt")))
+                .andExpect(jsonPath("$.deliveryLimit", is(15)));
+    }
+
+    @Test
+    public void whenUpdateACPDetails_withInvalidID_thenReturn_statusNotFound() throws Exception {
+        when(adminService.updateACPDetails(-2, null, null, null, "Lalaland", "Nevermore"))
+                .thenThrow(new ResourceNotFoundException("Couldn't find ACP with the ID -2!"));;
+
+
+        mockMvc.perform(
+                        put("/dropmate/admin/acp/-2").contentType(MediaType.APPLICATION_JSON)
+                                .param("city", "Lalaland")
+                                .param("address", "Nevermore"))
                 .andExpect(status().isNotFound());
     }
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -250,4 +250,45 @@ public class DropMate_IntegrationTest {
         }
     }
 
+    @Test
+    @Order(13)
+    public void whenUpdateACPDetails_withValidID_allFields_thenReturn_statusOK() throws Exception {
+        RestAssured.given().contentType("application/json")
+                .param("name", "test")
+                .param("email", "newemail@mail.pt")
+                .param("telephone", "000000000")
+                .param("city", "Lalaland")
+                .param("address", "Nevermore")
+                .when().put(BASE_URI + randomServerPort + "/dropmate/admin/acp/26")
+                .then().statusCode(200)
+                .body("city", is("Lalaland")).and()
+                .body("address", is("Nevermore")).and()
+                .body("email", is("newemail@mail.pt")).and()
+                .body("deliveryLimit", is(15));
+    }
+
+    @Test
+    @Order(14)
+    public void whenUpdateACPDetails_withValidID_somFields_thenReturn_statusOK() throws Exception {
+        RestAssured.given().contentType("application/json")
+                .param("city", "Lalaland")
+                .param("address", "Nevermore")
+                .when().put(BASE_URI + randomServerPort + "/dropmate/admin/acp/28")
+                .then().statusCode(200)
+                .body("city", is("Lalaland")).and()
+                .body("address", is("Nevermore")).and()
+                .body("email", is("pickuptwo@mail.pt")).and()
+                .body("deliveryLimit", is(15));
+    }
+
+    @Test
+    @Order(15)
+    public void whenUpdateACPDetails_withInvalidID_thenReturn_statusNotFound() throws Exception {
+        RestAssured.given().contentType("application/json")
+                .param("city", "Lalaland")
+                .param("address", "Nevermore")
+                .when().put(BASE_URI + randomServerPort + "/dropmate/admin/acp/-28")
+                .then().statusCode(404);
+    }
+
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -92,7 +92,46 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    @Order(1)
+    public void whenGetSpecificOperationStatistics_withValidID_thenReturn_statusOK() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/1/statistics")
+                .then().statusCode(200)
+                .body("total_parcels", is(10)).and()
+                .body("parcels_waiting_pickup", is(3)).and()
+                .body("parcels_in_delivery", is(5)).and()
+                .body("deliveryLimit", is(10));
+    }
+
+    @Test
+    @Order(2)
+    public void whenGetSpecificOperationStatistics_withInvalidID_thenReturn_statusOK() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/-21/statistics")
+                .then().statusCode(404);
+    }
+
+    @Test
     @Order(3)
+    public void whenGetSpecificACPDetails_withValidID_thenReturn_statusOK() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/5")
+                .then().statusCode(200)
+                .body("city", is("Aveiro")).and()
+                .body("address", is("Fake address 1, Aveiro")).and()
+                .body("deliveryLimit", is(10));
+    }
+
+    @Test
+    @Order(4)
+    public void whenGetSpecificACPDetails_withInvalidID_thenReturn_statusOK() {
+        RestAssured.with().contentType("application/json")
+                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/-21")
+                .then().statusCode(404);
+    }
+
+    @Test
+    @Order(5)
     public void whenGetAllACP_thenReturn_statusOK() throws Exception {
         RestAssured.with().contentType("application/json")
                 .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp")
@@ -104,7 +143,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Order(4)
+    @Order(6)
     public void whenGetAllAParcelsWaitDelivery_thenReturn_statusOK() throws Exception {
         parcelRepository.saveAndFlush(new Parcel("DEL123", "PCK123", 1.5, null, null, Status.IN_DELIVERY, testACP, testStore));
         parcelRepository.saveAndFlush(new Parcel("DEL456", "PCK456", 3.2, null, null, Status.IN_DELIVERY, testACP, testStore));
@@ -122,7 +161,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Order(5)
+    @Order(7)
     public void whenGetAllAParcelsWaitPickup_thenReturn_statusOK() throws Exception {
         parcelRepository.saveAndFlush(new Parcel("DEL123", "PCK123", 1.5, null, null, Status.IN_DELIVERY, testACP, testStore));
         parcelRepository.saveAndFlush(new Parcel("DEL456", "PCK456", 3.2, null, null, Status.IN_DELIVERY, testACP, testStore));
@@ -140,7 +179,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Order(6)
+    @Order(8)
     public void whenGetAllACPOperationalStatistics_thenReturn_statusOK() throws Exception {
         // Doing the test
         io.restassured.path.json.JsonPath path  = RestAssured.with().contentType("application/json")
@@ -156,26 +195,6 @@ public class DropMate_IntegrationTest {
             assertThat(value.containsKey("deliveryLimit"), equalTo(true));
             assertThat(value.containsKey("parcels_in_delivery"), equalTo(true));
         }
-    }
-
-    @Test
-    @Order(1)
-    public void whenGetSpecificOperationStatistics_withValidID_thenReturn_statusOK() {
-             RestAssured.with().contentType("application/json")
-                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/1/statistics")
-                .then().statusCode(200)
-                .body("total_parcels", is(10)).and()
-                .body("parcels_waiting_pickup", is(3)).and()
-                .body("parcels_in_delivery", is(5)).and()
-                .body("deliveryLimit", is(10));
-    }
-
-    @Test
-    @Order(2)
-    public void whenGetSpecificOperationStatistics_withInvalidID_thenReturn_statusOK() {
-        RestAssured.with().contentType("application/json")
-                .when().get(BASE_URI + randomServerPort + "/dropmate/admin/acp/-21/statistics")
-                .then().statusCode(404);
     }
 
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/repositoryTests/AcpRepositoryTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/repositoryTests/AcpRepositoryTest.java
@@ -1,7 +1,0 @@
-package tqs.dropmate.dropmate_backend.repositoryTests;
-
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-@DataJpaTest
-public class AcpRepositoryTest {
-}

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/repositoryTests/ParcelRepositoryTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/repositoryTests/ParcelRepositoryTest.java
@@ -1,7 +1,0 @@
-package tqs.dropmate.dropmate_backend.repositoryTests;
-
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-@DataJpaTest
-public class ParcelRepositoryTest {
-}

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/repositoryTests/StoreRepositoryTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/repositoryTests/StoreRepositoryTest.java
@@ -1,7 +1,0 @@
-package tqs.dropmate.dropmate_backend.repositoryTests;
-
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-@DataJpaTest
-public class StoreRepositoryTest {
-}

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
@@ -189,21 +189,41 @@ public class AdminService_UnitTest {
     }
 
     @Test
-    public void whenGetSpecificOperationalStatisics_withInvalidACP_thenReturnOnlySpecificACP() throws ResourceNotFoundException {
+    public void whenGetSpecificOperationalStatisics_withInvalidACP_thenReturnException() throws ResourceNotFoundException {
         // Set up Expectations
-        Map<String, Integer> statsMap = new HashMap<>();
-
-        statsMap.put("total_parcels", 10);
-        statsMap.put("parcels_in_delivery", 5);
-        statsMap.put("parcels_waiting_pickup", 3);
-
-        pickupPointOne.setOperationalStatistics(statsMap);
-
         when(acpRepository.findById(-5)).thenReturn(Optional.empty());
 
         // Verify the result is as expected
         assertThatThrownBy(() -> {
             adminService.getSpecificACPStatistics(-5);
+        }).isInstanceOf(ResourceNotFoundException.class).hasMessageContainingAll("Couldn't find ACP with the ID -5!");
+
+        // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
+        Mockito.verify(acpRepository, VerificationModeFactory.times(1)).findById(Mockito.any());
+    }
+
+    @Test
+    public void getACPDetails_withValidACP_thenReturnDetails() throws ResourceNotFoundException {
+        // Set up Expectations
+        when(acpRepository.findById(5)).thenReturn(Optional.ofNullable(pickupPointOne));
+
+        // Verify the result is as expected
+        AssociatedCollectionPoint acp = adminService.getACPDetails(5);
+
+        assertThat(acp).isEqualTo(pickupPointOne);
+
+        // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record
+        Mockito.verify(acpRepository, VerificationModeFactory.times(1)).findById(Mockito.any());
+    }
+
+    @Test
+    public void getACPDetails_withInvalidACP_thenReturnException() throws ResourceNotFoundException {
+        // Set up Expectations
+        when(acpRepository.findById(-5)).thenReturn(Optional.empty());
+
+        // Verify the result is as expected
+        assertThatThrownBy(() -> {
+            adminService.getACPDetails(-5);
         }).isInstanceOf(ResourceNotFoundException.class).hasMessageContainingAll("Couldn't find ACP with the ID -5!");
 
         // Verify that the external API was called and Verify that the cache was called twice - to query and to add the new record

--- a/DropMate_Backend/src/test/resources/application-integrationtest.properties
+++ b/DropMate_Backend/src/test/resources/application-integrationtest.properties
@@ -1,5 +1,0 @@
-spring.jpa.hibernate.ddl-auto=create-drop
-spring.datasource.url=jdbc:mysql://localhost:3306/testDatabase?allowPublicKeyRetrieval=true&useSSL=false
-spring.datasource.username=springuser
-spring.datasource.password=password
-spring.jackson.serialization.fail-on-empty-beans=false

--- a/DropMate_Backend/src/test/resources/application-test.properties
+++ b/DropMate_Backend/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
User Story: Admin Checks the Details of a Specific ACP
Jira Code: DM-20

Changes made:

- Completed the PUT "/acp/{acpID}" , GET "/acp/{acpID}", GET "/parcels/{acpID}/delivery" and GET "/parcels/{acpID}/pickup" API endpoints on Admin Controller.
- Completed the getACPDetails(), updateACPDetails(), getParcelsWaitingPickupAtACP() and getParcelsWaitingDeliveryAtACP() functions on Admin Service.
- Created the getACPFromID() auxilliary function on Admin Service and refactored existing code as needed.

Tests created:

- Admin Service Unit Test: Added the whenGetAllParcelWaitDelivery_atSpecificACP_withValidACP_thenReturnOnlyCorrectACP(), whenGetAllParcelWaitPickup_atSpecificACP_withValidACP_thenReturnOnlyCorrectACP(), whenGetAllParcelWaitDelivery_atSpecificACP_withInvalidACP_thenThrowException(), whenGetAllParcelWaitPickup_atSpecificACP_withValidACP_thenThrowException(), getACPDetails_withValidACP_thenReturnDetails(), getACPDetails_withInvalidACP_thenReturnException(), updateACPDetails_someFieldsPassed(),  updateACPDetails_allFieldsPassed(),   and updateACPDetails_invalidID() tests.
- Created the verifyFindByIdIsCalled() and verifyFindAllIsCalled() auxilliary functions and refactored existing code as needed.
- Admin controller boundary test: Added the whenUpdateACPDetails_withValidID_allFields_thenReturn_statusOK(), whenUpdateACPDetails_withValidID_somFields_thenReturn_statusOK(), whenUpdateACPDetails_withInvalidID_thenReturn_statusNotFound(), whenGetSpecificACPDetails_withInvalidID_thenReturn_statusNotFound(), whenGetSpecificACPDetails_withValidID_thenReturn_statusOK(), whenGetParcelsWaitingPickup_atSpecificACP_withInvalidID_thenReturn_statusNotFound(), whenGetParcelsWaitingDelivery_atSpecificACP_withInvalidID_thenReturn_statusNotFound() and whenGetParcelsWaitingPickup_atSpecificACP_withValidID_thenReturn_StatusOK() tests.
- Integration Test: Created the corresponding tests on this class.