### PR TITLE
Completed DM-21, DM-22 and DM-23

### DIFF
--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -33,12 +33,6 @@ public class AdminController {
         return ResponseEntity.ok().body(adminService.getAllACP());
     }
 
-    /** This method is used to associate a new ACP with the platform */
-    @PostMapping("/acp")
-    public ResponseEntity<SuccessfulRequest> addACP(@RequestParam(name = "acp") AssociatedCollectionPoint acp){
-        return null;
-    }
-
     /** Updates the details of an ACP */
     @PutMapping("/acp/{acpID}")
     public ResponseEntity<AssociatedCollectionPoint> updateACP(@PathVariable(name = "acpID") Integer acpID,
@@ -112,7 +106,15 @@ public class AdminController {
 
     /** Adds a new ACP to the pending list */
     @PostMapping("/acp/pending")
-    public ResponseEntity<SuccessfulRequest> addNewPendingACP(@RequestParam(name = "candidateACP") PendingACP candidateACP){return null;}
+    public ResponseEntity<PendingACP> addNewPendingACP(@RequestParam(name = "name") String name,
+                                                       @RequestParam(name = "email") String email,
+                                                       @RequestParam(name = "city") String city,
+                                                       @RequestParam(name = "address") String address,
+                                                       @RequestParam(name = "telephoneNumber") String telephoneNumber,
+                                                       @RequestParam(name = "description") String description) {
+
+        return ResponseEntity.ok().body(adminService.addNewPendingAcp(name, email, city, address, telephoneNumber, description));
+    }
 
     /** Gets all of the candidate ACP's  */
     @GetMapping("/acp/pending")

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -27,6 +27,10 @@ public class AdminController {
         return null;
     }
 
+
+    // ACP Methods
+
+
     /** This method returns all the ACP's associated with the Platform */
     @GetMapping("/acp")
     public ResponseEntity<List<AssociatedCollectionPoint>> getAllACP(){
@@ -56,11 +60,25 @@ public class AdminController {
         return null;
     }
 
+    /** Returns all the Operators associated with each ACP */
+    @GetMapping("/acp/operators")
+    public ResponseEntity<Map<AssociatedCollectionPoint, ACPOperator>> getAllOperators(){
+        return null;
+    }
+
+
+    // E-Store Methods
+
+
     /** This method returns all the E-Stores associated with the Platform */
     @GetMapping("/estores/")
     public ResponseEntity<List<Store>> getAllStores(){
         return null;
     }
+
+
+    // Operational Statistics
+
 
     /** This method returns the statistics associated with all ACPs */
     @GetMapping("/acp/statistics")
@@ -73,6 +91,10 @@ public class AdminController {
     public ResponseEntity<Map<String, Integer>> getACPStatistics(@PathVariable(name = "acpID") Integer acpID) throws ResourceNotFoundException {
         return ResponseEntity.ok().body(adminService.getSpecificACPStatistics(acpID));
     }
+
+
+    // Management of Parcels
+
 
     /** This method returns all the parcels waiting for delivery */
     @GetMapping("/parcels/all/delivery")
@@ -98,11 +120,9 @@ public class AdminController {
         return ResponseEntity.ok().body(adminService.getParcelsWaitingPickupAtACP(acpID));
     }
 
-    /** Returns all the Operators associated with each ACP */
-    @GetMapping("/acp/operators")
-    public ResponseEntity<Map<AssociatedCollectionPoint, ACPOperator>> getAllOperators(){
-        return null;
-    }
+
+    // Management of Pending ACP's
+
 
     /** Adds a new ACP to the pending list */
     @PostMapping("/acp/pending")
@@ -121,8 +141,9 @@ public class AdminController {
     public ResponseEntity<List<PendingACP>> getPendingACP(){return null;}
 
     /** Changes the status of a candidate ACP */
-    @PostMapping("/acp/pending/{acpID}/status")
-    public ResponseEntity<SuccessfulRequest> changePendingACPStatus(@PathVariable(name = "candidateACP") PendingACP candidateACP,
-                                                                    @RequestParam(name = "oldStatus") Integer oldStatus,
-                                                                    @RequestParam(name = "newStatus") Integer newStatus) {return null;}
+    @PutMapping("/acp/pending/{acpID}/status")
+    public ResponseEntity<SuccessfulRequest> changePendingACPStatus(@PathVariable(name = "acpID") Integer candidateID,
+                                                                    @RequestParam(name = "newStatus") Integer newStatus) throws ResourceNotFoundException {
+        return ResponseEntity.ok().body(adminService.changePendingACPStatus(candidateID, newStatus));
+    }
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/ParcelRepository.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/ParcelRepository.java
@@ -1,7 +1,9 @@
 package tqs.dropmate.dropmate_backend.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import tqs.dropmate.dropmate_backend.datamodel.Parcel;
 
+@Repository
 public interface ParcelRepository extends JpaRepository<Parcel, Integer> {
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/PendingAssociatedCollectionPointRepository.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/PendingAssociatedCollectionPointRepository.java
@@ -1,0 +1,10 @@
+package tqs.dropmate.dropmate_backend.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import tqs.dropmate.dropmate_backend.datamodel.PendingACP;
+
+@Repository
+public interface PendingAssociatedCollectionPointRepository extends JpaRepository<PendingACP, Integer> {
+    PendingACP findFirstByName(String name);
+}

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/StoreRepository.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/StoreRepository.java
@@ -1,7 +1,9 @@
 package tqs.dropmate.dropmate_backend.repositories;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import tqs.dropmate.dropmate_backend.datamodel.Store;
 
+@Repository
 public interface StoreRepository extends JpaRepository<Store, Integer> {
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -4,11 +4,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
 import tqs.dropmate.dropmate_backend.datamodel.Parcel;
+import tqs.dropmate.dropmate_backend.datamodel.PendingACP;
 import tqs.dropmate.dropmate_backend.datamodel.Status;
 import tqs.dropmate.dropmate_backend.exceptions.ResourceNotFoundException;
 import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
 import tqs.dropmate.dropmate_backend.repositories.ParcelRepository;
-import tqs.dropmate.dropmate_backend.utils.SuccessfulRequest;
+import tqs.dropmate.dropmate_backend.repositories.PendingAssociatedCollectionPointRepository;
 
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +22,8 @@ public class AdminService {
     private AssociatedCollectionPointRepository acpRepository;
     @Autowired
     private ParcelRepository parcelRepository;
+    @Autowired
+    private PendingAssociatedCollectionPointRepository pendingACPRepository;
 
     /** This method returns all the ACP's associated with the Platform */
     public List<AssociatedCollectionPoint> getAllACP(){
@@ -117,7 +120,7 @@ public class AdminService {
      * @param telephone - Updated telephone for the ACP. Could be null
      * @param city - Updated city for the ACP. Could be null
      * @param address - Updated address for the ACP. Could be null
-     * @return a message stating the Request was Succesful
+     * @return the updated ACP
      * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
      * */
     public AssociatedCollectionPoint updateACPDetails(Integer acpID, String email, String name, String telephone, String city, String address) throws ResourceNotFoundException {
@@ -132,6 +135,31 @@ public class AdminService {
         acpRepository.save(acp);
 
         return acp;
+    }
+
+    /** Adds a new ACP to the pending list
+     * @param email - Updated email for the ACP. Could be null
+     * @param name - Updated name for the ACP. Could be null
+     * @param telephoneNumber - Updated telephone for the ACP. Could be null
+     * @param city - Updated city for the ACP. Could be null
+     * @param address - Updated address for the ACP. Could be null
+     * @param description - A small text explaining why this store wants to be a Partner ACP
+     * @return the entity for the new Pending ACP, including its ID
+     * */
+    public PendingACP addNewPendingAcp(String name, String email, String city, String address, String telephoneNumber, String description){
+        PendingACP newCandidateACP = new PendingACP();
+
+        newCandidateACP.setName(name);
+        newCandidateACP.setEmail(email);
+        newCandidateACP.setCity(city);
+        newCandidateACP.setAddress(address);
+        newCandidateACP.setTelephoneNumber(telephoneNumber);
+        newCandidateACP.setDescription(description);
+        newCandidateACP.setStatus(0);
+
+        pendingACPRepository.save(newCandidateACP);
+
+        return pendingACPRepository.findFirstByName(name);
     }
 
 

--- a/DropMate_Backend/src/main/resources/application.properties
+++ b/DropMate_Backend/src/main/resources/application.properties
@@ -10,3 +10,5 @@ spring.jpa.show-sql=true
 # Local
 spring.datasource.url=jdbc:mysql://localhost:3306/DropMate?allowPublicKeyRetrieval=true&useSSL=false
 
+logging.level.root=DEBUG
+

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -291,4 +291,23 @@ public class DropMate_IntegrationTest {
                 .then().statusCode(404);
     }
 
+    @Test
+    @Disabled
+    void whenAddNewPendingACP_thenReturn_correspondingACP() throws Exception {
+        RestAssured.given().contentType("application/json")
+                .param("city", "Aveiro")
+                .param("address", "Fake Street no 1, Aveiro")
+                .param("name", "Test New ACP")
+                .param("email", "newacp@mail.pt")
+                .param("telephoneNumber", "000000000")
+                .param("description", "I am a totally legit pickup point")
+                .when().post(BASE_URI + randomServerPort + "/dropmate/admin/acp/pending")
+                .then().statusCode(200)
+                .body("city", is("Aveiro")).and()
+                .body("address", is("Fake Street no 1, Aveiro")).and()
+                .body("email", is("newacp@mail.pt")).and()
+                .body("acpId", is(1)).and()
+                .body("status", is(0));
+    }
+
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
@@ -19,6 +19,7 @@ import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepos
 import tqs.dropmate.dropmate_backend.repositories.ParcelRepository;
 import tqs.dropmate.dropmate_backend.repositories.PendingAssociatedCollectionPointRepository;
 import tqs.dropmate.dropmate_backend.services.AdminService;
+import tqs.dropmate.dropmate_backend.utils.SuccessfulRequest;
 
 import java.sql.Date;
 import java.util.*;
@@ -361,6 +362,7 @@ public class AdminService_UnitTest {
 
     @Test
     void addNewCandidateACP_thenReturnNewPendingACP() {
+        // Preparing the test
         PendingACP candidateACP = new PendingACP();
         candidateACP.setName("Test New ACP");
         candidateACP.setEmail("newacp@mail.pt");
@@ -380,6 +382,81 @@ public class AdminService_UnitTest {
 
         // Mockito verifications
         Mockito.verify(pendingACPRepository, VerificationModeFactory.times(1)).findFirstByName(Mockito.any());
+    }
+
+    @Test
+    void reviewCandidateACP_notReviewedBefore_acceptACP() throws ResourceNotFoundException {
+        // Preparing the test
+        PendingACP candidateACP = new PendingACP();
+        candidateACP.setName("Test New ACP");
+        candidateACP.setEmail("newacp@mail.pt");
+        candidateACP.setCity("Aveiro");
+        candidateACP.setAddress("Fake Street no 1, Aveiro");
+        candidateACP.setTelephoneNumber("000000000");
+        candidateACP.setDescription("I am a totally legit pickup point");
+        candidateACP.setStatus(0);
+        candidateACP.setAcpId(1);
+
+        // Set up Expectations
+        when(pendingACPRepository.findById(1)).thenReturn(Optional.of(candidateACP));
+
+        // Verify the result is as expected
+        assertThat(adminService.changePendingACPStatus(1, 2))
+                .extracting(SuccessfulRequest::getMessage).isEqualTo("Request accepted!");
+
+        // Mockito verifications
+        Mockito.verify(pendingACPRepository, VerificationModeFactory.times(1)).findById(Mockito.any());
+        Mockito.verify(pendingACPRepository, VerificationModeFactory.times(1)).save(Mockito.any());
+        Mockito.verify(acpRepository, VerificationModeFactory.times(1)).save(Mockito.any());
+    }
+
+    @Test
+    void reviewCandidateACP_notReviewedBefore_rejectACP() throws ResourceNotFoundException {
+        // Preparing the test
+        PendingACP candidateACP = new PendingACP();
+        candidateACP.setName("Test New ACP");
+        candidateACP.setEmail("newacp@mail.pt");
+        candidateACP.setCity("Aveiro");
+        candidateACP.setAddress("Fake Street no 1, Aveiro");
+        candidateACP.setTelephoneNumber("000000000");
+        candidateACP.setDescription("I am a totally legit pickup point");
+        candidateACP.setStatus(0);
+        candidateACP.setAcpId(1);
+
+        // Set up Expectations
+        when(pendingACPRepository.findById(1)).thenReturn(Optional.of(candidateACP));
+
+        // Verify the result is as expected
+        assertThat(adminService.changePendingACPStatus(1, 1))
+                .extracting(SuccessfulRequest::getMessage).isEqualTo("Request rejected!");
+
+        // Mockito verifications
+        Mockito.verify(pendingACPRepository, VerificationModeFactory.times(1)).findById(Mockito.any());
+        Mockito.verify(pendingACPRepository, VerificationModeFactory.times(1)).save(Mockito.any());
+    }
+
+    @Test
+    void reviewCandidateACP_reviewedBefore_thenRejectNewEvaluation() throws ResourceNotFoundException {
+        // Preparing the test
+        PendingACP candidateACP = new PendingACP();
+        candidateACP.setName("Test New ACP");
+        candidateACP.setEmail("newacp@mail.pt");
+        candidateACP.setCity("Aveiro");
+        candidateACP.setAddress("Fake Street no 1, Aveiro");
+        candidateACP.setTelephoneNumber("000000000");
+        candidateACP.setDescription("I am a totally legit pickup point");
+        candidateACP.setStatus(1);
+        candidateACP.setAcpId(1);
+
+        // Set up Expectations
+        when(pendingACPRepository.findById(1)).thenReturn(Optional.of(candidateACP));
+
+        // Verify the result is as expected
+        assertThat(adminService.changePendingACPStatus(1, 1))
+                .extracting(SuccessfulRequest::getMessage).isEqualTo("Operation denied, as this candidate request has already been reviewed!");
+
+        // Mockito verifications
+        Mockito.verify(pendingACPRepository, VerificationModeFactory.times(1)).findById(Mockito.any());
     }
 
     // Auxilliary functions

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
@@ -12,10 +12,12 @@ import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
 import tqs.dropmate.dropmate_backend.datamodel.Parcel;
+import tqs.dropmate.dropmate_backend.datamodel.PendingACP;
 import tqs.dropmate.dropmate_backend.datamodel.Status;
 import tqs.dropmate.dropmate_backend.exceptions.ResourceNotFoundException;
 import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
 import tqs.dropmate.dropmate_backend.repositories.ParcelRepository;
+import tqs.dropmate.dropmate_backend.repositories.PendingAssociatedCollectionPointRepository;
 import tqs.dropmate.dropmate_backend.services.AdminService;
 
 import java.sql.Date;
@@ -31,6 +33,8 @@ public class AdminService_UnitTest {
     private AssociatedCollectionPointRepository acpRepository;
     @Mock(lenient = true)
     private ParcelRepository parcelRepository;
+    @Mock(lenient = true)
+    private PendingAssociatedCollectionPointRepository pendingACPRepository;
 
     @InjectMocks
     private AdminService adminService;
@@ -353,6 +357,29 @@ public class AdminService_UnitTest {
 
         // Mockito verifications
         this.verifyFindByIdIsCalled();
+    }
+
+    @Test
+    void addNewCandidateACP_thenReturnNewPendingACP() {
+        PendingACP candidateACP = new PendingACP();
+        candidateACP.setName("Test New ACP");
+        candidateACP.setEmail("newacp@mail.pt");
+        candidateACP.setCity("Aveiro");
+        candidateACP.setAddress("Fake Street no 1, Aveiro");
+        candidateACP.setTelephoneNumber("000000000");
+        candidateACP.setDescription("I am a totally legit pickup point");
+        candidateACP.setStatus(0);
+        candidateACP.setAcpId(1);
+
+        // Set up Expectations
+        when(pendingACPRepository.findFirstByName("Test New ACP")).thenReturn(candidateACP);
+
+        // Verify the result is as expected
+        assertThat(adminService.addNewPendingAcp("Test New ACP", "newacp@mail.pt", "Aveiro", "Fake Street no 1, Aveiro", "000000000", "I am a totally legit pickup point"))
+                .isEqualTo(candidateACP);
+
+        // Mockito verifications
+        Mockito.verify(pendingACPRepository, VerificationModeFactory.times(1)).findFirstByName(Mockito.any());
     }
 
     // Auxilliary functions


### PR DESCRIPTION
User Story: Admin Reviews Requests of New ACPs, Admin Accepts a Request for a New ACP and Admin Rejects a Request for a New ACP
Jira Code: DM-21, DM-22 and DM-23

Changes made:

- Completed the PUT "/acp/pending/{acpID}/status" and POST "/acp/pending" API endpoints on Admin Controller.
- Completed the changePendingACPStatus() and  addNewPendingAcp() functions on Admin Service.

Tests created:

- Admin Service Unit Test: Added the reviewCandidateACP_reviewedBefore_thenRejectNewEvaluation(), reviewCandidateACP_notReviewedBefore_rejectACP(), reviewCandidateACP_notReviewedBefore_acceptACP(), addNewCandidateACP_thenReturnNewPendingACP() tests.
- Admin controller boundary test: Added the reviewCandidateACP_withInvalidID_thenReceiveException(), reviewCandidateACP_withValidID_reviewedBefore_thenRejectNewEvaluation(), reviewCandidateACP_withValidID_notReviewedBefore_rejectACP(), reviewCandidateACP_withValidID_notReviewedBefore_thenAcceptACP(), whenAddNewPendingACP_thenReturn_correspondingACP() tests.
- Integration Test: Created the corresponding tests on this class.