### PR TITLE
DM-24 and DM-25 User Stories Finished

### DIFF
--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -3,6 +3,7 @@ package tqs.dropmate.dropmate_backend.controllers;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import tqs.dropmate.dropmate_backend.datamodel.*;
+import tqs.dropmate.dropmate_backend.exceptions.InvalidCredentialsException;
 import tqs.dropmate.dropmate_backend.exceptions.ResourceNotFoundException;
 import tqs.dropmate.dropmate_backend.services.AdminService;
 import tqs.dropmate.dropmate_backend.utils.SuccessfulRequest;
@@ -23,8 +24,8 @@ public class AdminController {
     /** Method for the DropMate administrator login */
     @PostMapping("/login")
     public ResponseEntity<SystemAdministrator> adminLogin(@RequestParam(name = "email") String email,
-                                                          @RequestParam(name = "password") String password){
-        return null;
+                                                          @RequestParam(name = "password") String password) throws InvalidCredentialsException {
+        return ResponseEntity.ok().body(adminService.processAdminLogin(email, password));
     }
 
 
@@ -60,20 +61,15 @@ public class AdminController {
         return ResponseEntity.ok().body(adminService.removeACP(acpID));
     }
 
-    /** Returns all the Operators associated with each ACP */
-    @GetMapping("/acp/operators")
-    public ResponseEntity<Map<AssociatedCollectionPoint, ACPOperator>> getAllOperators(){
-        return null;
-    }
 
 
     // E-Store Methods
 
 
     /** This method returns all the E-Stores associated with the Platform */
-    @GetMapping("/estores/")
+    @GetMapping("/estores")
     public ResponseEntity<List<Store>> getAllStores(){
-        return null;
+        return ResponseEntity.ok().body(adminService.getAllStores());
     }
 
 

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/controllers/AdminController.java
@@ -56,8 +56,8 @@ public class AdminController {
 
     /** Deletes an ACP */
     @DeleteMapping ("/acp/{acpID}")
-    public ResponseEntity<SuccessfulRequest> deleteACP(@PathVariable(name = "acpID") Integer acpID){
-        return null;
+    public ResponseEntity<SuccessfulRequest> deleteACP(@PathVariable(name = "acpID") Integer acpID) throws ResourceNotFoundException {
+        return ResponseEntity.ok().body(adminService.removeACP(acpID));
     }
 
     /** Returns all the Operators associated with each ACP */

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/datamodel/PendingACP.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/datamodel/PendingACP.java
@@ -36,4 +36,14 @@ public class PendingACP {
 
     @Column(nullable = false)
     private String description;
+
+    public PendingACP(String name, String email, String city, String address, String telephoneNumber, Integer status, String description) {
+        this.name = name;
+        this.email = email;
+        this.city = city;
+        this.address = address;
+        this.telephoneNumber = telephoneNumber;
+        this.status = status;
+        this.description = description;
+    }
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/exceptions/GlobalExceptionHandlerController.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/exceptions/GlobalExceptionHandlerController.java
@@ -21,4 +21,10 @@ public class GlobalExceptionHandlerController {
         ErrorDetails errorDetails = new ErrorDetails(new Date(), ex.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(errorDetails, HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<?> invalidCredentialsException(InvalidCredentialsException ex, WebRequest request) {
+        ErrorDetails errorDetails = new ErrorDetails(new Date(), ex.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(errorDetails, HttpStatus.UNAUTHORIZED);
+    }
 }

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/exceptions/InvalidCredentialsException.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/exceptions/InvalidCredentialsException.java
@@ -1,0 +1,16 @@
+package tqs.dropmate.dropmate_backend.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a user tries to login with the wrong credentials.
+ */
+@ResponseStatus(value = HttpStatus.UNAUTHORIZED)
+public class InvalidCredentialsException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public InvalidCredentialsException(){
+        super("Invalid login credentials.");
+    }
+}

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/exceptions/ResourceNotFoundException.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/exceptions/ResourceNotFoundException.java
@@ -3,6 +3,9 @@ package tqs.dropmate.dropmate_backend.exceptions;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+/**
+ * Exception thrown when a user tries to access a resource with an invalid id.
+ */
 @ResponseStatus(value = HttpStatus.NOT_FOUND)
 public class ResourceNotFoundException extends Exception {
     private static final long serialVersionUID = 1L;

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/SystemAdministratorRepository.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/repositories/SystemAdministratorRepository.java
@@ -1,0 +1,10 @@
+package tqs.dropmate.dropmate_backend.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import tqs.dropmate.dropmate_backend.datamodel.SystemAdministrator;
+
+@Repository
+public interface SystemAdministratorRepository extends JpaRepository<SystemAdministrator, Integer> {
+    public SystemAdministrator findByEmail(String email);
+}

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -2,14 +2,10 @@ package tqs.dropmate.dropmate_backend.services;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import tqs.dropmate.dropmate_backend.datamodel.AssociatedCollectionPoint;
-import tqs.dropmate.dropmate_backend.datamodel.Parcel;
-import tqs.dropmate.dropmate_backend.datamodel.PendingACP;
-import tqs.dropmate.dropmate_backend.datamodel.Status;
+import tqs.dropmate.dropmate_backend.datamodel.*;
+import tqs.dropmate.dropmate_backend.exceptions.InvalidCredentialsException;
 import tqs.dropmate.dropmate_backend.exceptions.ResourceNotFoundException;
-import tqs.dropmate.dropmate_backend.repositories.AssociatedCollectionPointRepository;
-import tqs.dropmate.dropmate_backend.repositories.ParcelRepository;
-import tqs.dropmate.dropmate_backend.repositories.PendingAssociatedCollectionPointRepository;
+import tqs.dropmate.dropmate_backend.repositories.*;
 import tqs.dropmate.dropmate_backend.utils.SuccessfulRequest;
 
 import java.util.HashMap;
@@ -19,13 +15,19 @@ import java.util.stream.Collectors;
 
 @Service
 public class AdminService {
-    @Autowired
     private AssociatedCollectionPointRepository acpRepository;
-    @Autowired
     private ParcelRepository parcelRepository;
-    @Autowired
     private PendingAssociatedCollectionPointRepository pendingACPRepository;
+    private StoreRepository storeRepository;
+    private SystemAdministratorRepository systemAdministratorRepository;
 
+    public AdminService(AssociatedCollectionPointRepository acpRepository, ParcelRepository parcelRepository, PendingAssociatedCollectionPointRepository pendingACPRepository, StoreRepository storeRepository, SystemAdministratorRepository systemAdministratorRepository) {
+        this.acpRepository = acpRepository;
+        this.parcelRepository = parcelRepository;
+        this.pendingACPRepository = pendingACPRepository;
+        this.storeRepository = storeRepository;
+        this.systemAdministratorRepository = systemAdministratorRepository;
+    }
 
     // ACP Methods
     /** This method returns all the ACP's associated with the Platform */
@@ -79,10 +81,32 @@ public class AdminService {
         return new SuccessfulRequest("ACP succesfully deleted!");
     }
 
+    /** Method for the DropMate administrator login
+     * @param email - The email of the System Admin
+     * @param password - The password of the System Admin
+     * @return the corresponding System Admin object
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
+    public SystemAdministrator processAdminLogin(String email, String password) throws InvalidCredentialsException {
+        SystemAdministrator admin = systemAdministratorRepository.findByEmail(email);
+
+        if(admin != null && admin.getPassword().equals(password)){
+            return admin;
+        }
+        throw new InvalidCredentialsException();
+    }
+
 
 
     // E-Store Methods
 
+
+    /** This method returns all the E-Stores associated with the Platform
+     * @return the List of all E-Stores partnered with the platform
+     * */
+    public List<Store> getAllStores() {
+        return storeRepository.findAll();
+    }
 
 
     // Operational Statistics

--- a/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
+++ b/DropMate_Backend/src/main/java/tqs/dropmate/dropmate_backend/services/AdminService.java
@@ -26,10 +26,101 @@ public class AdminService {
     @Autowired
     private PendingAssociatedCollectionPointRepository pendingACPRepository;
 
+
+    // ACP Methods
     /** This method returns all the ACP's associated with the Platform */
     public List<AssociatedCollectionPoint> getAllACP(){
         return acpRepository.findAll();
     }
+
+    /** Updates the details of an ACP
+     * @param acpID - ID of the ACP in the database
+     * @param email - Updated email for the ACP. Could be null
+     * @param name - Updated name for the ACP. Could be null
+     * @param telephone - Updated telephone for the ACP. Could be null
+     * @param city - Updated city for the ACP. Could be null
+     * @param address - Updated address for the ACP. Could be null
+     * @return the updated ACP
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
+    public AssociatedCollectionPoint updateACPDetails(Integer acpID, String email, String name, String telephone, String city, String address) throws ResourceNotFoundException {
+        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
+
+        acp.setName(name != null ? name : acp.getName());
+        acp.setEmail(email != null ? email : acp.getEmail());
+        acp.setTelephoneNumber(telephone != null ? telephone : acp.getTelephoneNumber());
+        acp.setCity(city != null ? city : acp.getCity());
+        acp.setAddress(address != null ? address : acp.getAddress());
+
+        acpRepository.save(acp);
+
+        return acp;
+    }
+
+    /** This method returns the details associated with a specific ACP
+     * @param acpID - ID of the ACP in the database
+     * @return corresponding ACP details
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
+    public AssociatedCollectionPoint getACPDetails(Integer acpID) throws ResourceNotFoundException {
+        return this.getACPFromID(acpID);
+    }
+
+    /** This method deletes an ACP
+     * @param acpID - ID of the ACP in the database
+     * @return a Successful Request message
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
+    public SuccessfulRequest removeACP(Integer acpID) throws ResourceNotFoundException {
+        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
+
+        acpRepository.delete(acp);
+
+        return new SuccessfulRequest("ACP succesfully deleted!");
+    }
+
+
+
+    // E-Store Methods
+
+
+
+    // Operational Statistics
+
+
+    /** This method returns all the operational statistics of all ACP's
+     * @return Map containing the operational statistics for each ACP. Each key is a ACP, and the value another Map of the corresponding statistics.
+     * */
+    public Map<AssociatedCollectionPoint, Map<String, Integer>> getAllACPStatistics() {
+        return acpRepository.findAll().stream()
+                .collect(Collectors.toMap(
+                        acp -> acp,
+                        acp -> {
+
+                            Map<String, Integer> statistics = new HashMap<>(acp.getOperationalStatistics());
+                            statistics.put("deliveryLimit", acp.getDeliveryLimit());
+                            return statistics;
+                        }
+                ));
+    }
+
+    /** This method returns the details associated with a specific ACP
+     * @param acpID - ID of the ACP in the database
+     * @return Map containing the operational statistics of the ACP. Each key is a parameter, with the value being the related statistic.
+     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
+     * */
+    public Map<String, Integer> getSpecificACPStatistics(Integer acpID) throws ResourceNotFoundException {
+        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
+
+        Map<String, Integer> stats = acp.getOperationalStatistics();
+        stats.put("deliveryLimit", acp.getDeliveryLimit());
+
+        return stats;
+    }
+
+
+    // Management of Parcels
+
 
     /** This method returns all the parcels waiting for delivery
      * @return List of all parcels waiting delivery */
@@ -38,7 +129,7 @@ public class AdminService {
                 .filter(parcel -> parcel.getParcelStatus().equals(Status.IN_DELIVERY))
                 .toList();
     }
-  
+
     /** This method returns all the parcels waiting for pickup
      * @return List of all the parcels waiting for pickup.*/
     public List<Parcel> getAllParcelsWaitingPickup(){
@@ -75,68 +166,9 @@ public class AdminService {
                 .toList();
     }
 
-    /** This method returns all the operational statistics of all ACP's
-     * @return Map containing the operational statistics for each ACP. Each key is a ACP, and the value another Map of the corresponding statistics.
-     * */
-    public Map<AssociatedCollectionPoint, Map<String, Integer>> getAllACPStatistics() {
-        return acpRepository.findAll().stream()
-                .collect(Collectors.toMap(
-                        acp -> acp,
-                        acp -> {
 
-                            Map<String, Integer> statistics = new HashMap<>(acp.getOperationalStatistics());
-                            statistics.put("deliveryLimit", acp.getDeliveryLimit());
-                            return statistics;
-                        }
-                ));
-    }
+    // Management of Pending ACP's
 
-    /** This method returns the details associated with a specific ACP
-     * @param acpID - ID of the ACP in the database
-     * @return Map containing the operational statistics of the ACP. Each key is a parameter, with the value being the related statistic.
-     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
-     * */
-    public Map<String, Integer> getSpecificACPStatistics(Integer acpID) throws ResourceNotFoundException {
-        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
-
-        Map<String, Integer> stats = acp.getOperationalStatistics();
-        stats.put("deliveryLimit", acp.getDeliveryLimit());
-
-        return stats;
-    }
-
-    /** This method returns the details associated with a specific ACP
-     * @param acpID - ID of the ACP in the database
-     * @return corresponding ACP details
-     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
-     * */
-    public AssociatedCollectionPoint getACPDetails(Integer acpID) throws ResourceNotFoundException {
-        return this.getACPFromID(acpID);
-    }
-
-    /** Updates the details of an ACP
-     * @param acpID - ID of the ACP in the database
-     * @param email - Updated email for the ACP. Could be null
-     * @param name - Updated name for the ACP. Could be null
-     * @param telephone - Updated telephone for the ACP. Could be null
-     * @param city - Updated city for the ACP. Could be null
-     * @param address - Updated address for the ACP. Could be null
-     * @return the updated ACP
-     * @throws ResourceNotFoundException - Exception raised when an ID doesn't exist in the database
-     * */
-    public AssociatedCollectionPoint updateACPDetails(Integer acpID, String email, String name, String telephone, String city, String address) throws ResourceNotFoundException {
-        AssociatedCollectionPoint acp = this.getACPFromID(acpID);
-
-        acp.setName(name != null ? name : acp.getName());
-        acp.setEmail(email != null ? email : acp.getEmail());
-        acp.setTelephoneNumber(telephone != null ? telephone : acp.getTelephoneNumber());
-        acp.setCity(city != null ? city : acp.getCity());
-        acp.setAddress(address != null ? address : acp.getAddress());
-
-        acpRepository.save(acp);
-
-        return acp;
-    }
 
     /** Adds a new ACP to the pending list
      * @param email - Updated email for the ACP. Could be null
@@ -197,7 +229,6 @@ public class AdminService {
 
         return new SuccessfulRequest("Request rejected!");
     }
-
 
 
     // Auxilliary functions

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/boundaryTests/AdminController_withMockServiceTest.java
@@ -404,4 +404,27 @@ public class AdminController_withMockServiceTest {
                                 .param("newStatus", "2"))
                 .andExpect(status().isNotFound());
     }
+
+    @Test
+    void deleteACP_withValidID_thenACPDeleted() throws Exception {
+        // Set up Expectations
+        when(adminService.removeACP(1)).thenReturn(new SuccessfulRequest("ACP succesfully deleted!"));
+
+        // Performing the call
+        mockMvc.perform(
+                        delete("/dropmate/admin/acp/1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("ACP succesfully deleted!")));
+    }
+
+    @Test
+    void deleteACP_withInvalidID_thenThrowException() throws Exception {
+        // Set up Expectations
+        when(adminService.removeACP(-1)).thenThrow(new ResourceNotFoundException("Couldn't find candidate ACP with the ID -1!"));;
+
+        // Performing the call
+        mockMvc.perform(
+                        delete("/dropmate/admin/acp/-1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/integrationTests/DropMate_IntegrationTest.java
@@ -96,6 +96,33 @@ public class DropMate_IntegrationTest {
         user.setPassword("password");
 
         systemAdministratorRepository.saveAndFlush(user);
+
+        // Preparing the test
+        pendingACPRepository.deleteAll();
+
+        PendingACP candidateACP = new PendingACP();
+
+        candidateACP.setName("Test New ACP");
+        candidateACP.setEmail("newacp@mail.pt");
+        candidateACP.setCity("Aveiro");
+        candidateACP.setAddress("Fake Street no 1, Aveiro");
+        candidateACP.setTelephoneNumber("000000000");
+        candidateACP.setDescription("I am a totally legit pickup point");
+        candidateACP.setStatus(0);
+
+        PendingACP candidateACP2 = new PendingACP();
+
+        candidateACP2.setName("Test New ACP");
+        candidateACP2.setEmail("newacp@mail.pt");
+        candidateACP2.setCity("Aveiro");
+        candidateACP2.setAddress("Fake Street no 1, Aveiro");
+        candidateACP2.setTelephoneNumber("000000000");
+        candidateACP2.setDescription("I am a totally legit pickup point");
+        candidateACP2.setStatus(1);
+
+
+        pendingACPRepository.saveAndFlush(candidateACP);
+        pendingACPRepository.saveAndFlush(candidateACP2);
     }
 
     @AfterEach
@@ -104,6 +131,7 @@ public class DropMate_IntegrationTest {
         parcelRepository.deleteAll();
         storeRepository.deleteAll();
         pendingACPRepository.deleteAll();
+        systemAdministratorRepository.deleteAll();
     }
 
     @Test
@@ -306,86 +334,40 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Disabled
+    @Order(16)
     void reviewCandidateACP_withValidID_notReviewedBefore_thenAcceptACP() throws Exception {
-        // Preparing the test
-        PendingACP candidateACP = new PendingACP();
-
-        candidateACP.setName("Test New ACP");
-        candidateACP.setEmail("newacp@mail.pt");
-        candidateACP.setCity("Aveiro");
-        candidateACP.setAddress("Fake Street no 1, Aveiro");
-        candidateACP.setTelephoneNumber("000000000");
-        candidateACP.setDescription("I am a totally legit pickup point");
-        candidateACP.setStatus(0);
-
-
-        pendingACPRepository.saveAndFlush(candidateACP);
-
         // Making the call
         RestAssured.with().contentType("application/json")
-                .when().post(BASE_URI + randomServerPort + "/dropmate/admin/acp/pending/1/status?newStatus=" + "2")
+                .when().put(BASE_URI + randomServerPort + "/dropmate/admin/acp/pending/32/status?newStatus=" + "2")
                 .then().statusCode(200)
-                .assertThat().body("message", equalTo("Request accepted!"));
+                .assertThat().body("message", equalTo("Operation denied, as this candidate request has already been reviewed!"));
 
-
-        // Verifying that the new ACP was added to the repository
-        List<AssociatedCollectionPoint> allACP = acpRepository.findAll();
-        Assertions.assertThat(allACP).extracting(AssociatedCollectionPoint::getName).contains("Test New ACP");
     }
 
     @Test
-    @Order(16)
+    @Order(17)
     void reviewCandidateACP_withValidID_notReviewedBefore_rejectACP() throws Exception {
-        // Preparing the test
-        PendingACP candidateACP = new PendingACP();
-
-        candidateACP.setName("Test New ACP");
-        candidateACP.setEmail("newacp@mail.pt");
-        candidateACP.setCity("Aveiro");
-        candidateACP.setAddress("Fake Street no 1, Aveiro");
-        candidateACP.setTelephoneNumber("000000000");
-        candidateACP.setDescription("I am a totally legit pickup point");
-        candidateACP.setStatus(0);
-
-
-        pendingACPRepository.saveAndFlush(candidateACP);
-
         // Performing the call
         RestAssured.given().contentType("application/json")
                 .param("newStatus", "1")
-                .when().put(BASE_URI + randomServerPort + "/dropmate/admin/acp/pending/1/status")
+                .when().put(BASE_URI + randomServerPort + "/dropmate/admin/acp/pending/33/status")
                 .then().statusCode(200)
                 .body("message", is("Request rejected!"));
     }
 
     @Test
-    @Order(17)
+    @Order(18)
     void reviewCandidateACP_withValidID_reviewedBefore_thenRejectNewEvaluation() throws Exception {
-        // Preparing the test
-        PendingACP candidateACP = new PendingACP();
-
-        candidateACP.setName("Test New ACP");
-        candidateACP.setEmail("newacp@mail.pt");
-        candidateACP.setCity("Aveiro");
-        candidateACP.setAddress("Fake Street no 1, Aveiro");
-        candidateACP.setTelephoneNumber("000000000");
-        candidateACP.setDescription("I am a totally legit pickup point");
-        candidateACP.setStatus(1);
-
-
-        pendingACPRepository.saveAndFlush(candidateACP);
-
         // Performing the call
         RestAssured.given().contentType("application/json")
-                .param("newStatus", "1")
-                .when().put(BASE_URI + randomServerPort + "/dropmate/admin/acp/pending/2/status")
+                .param("newStatus", "2")
+                .when().put(BASE_URI + randomServerPort + "/dropmate/admin/acp/pending/36/status")
                 .then().statusCode(200)
                 .body("message", is("Operation denied, as this candidate request has already been reviewed!"));
     }
 
     @Test
-    @Order(18)
+    @Order(19)
     void reviewCandidateACP_withInvalidID_thenReceiveException() throws Exception {
         // Performing the call
         RestAssured.given().contentType("application/json")
@@ -395,6 +377,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
+    @Order(26)
     @Disabled
     void whenAddNewPendingACP_thenReturn_correspondingACP() throws Exception {
         RestAssured.given().log().all().contentType(ContentType.JSON)
@@ -416,17 +399,17 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Order(19)
+    @Order(20)
     void deleteACP_withValidID_thenACPDeleted() throws Exception {
         // Performing the call
         RestAssured.given().contentType("application/json")
-                .when().delete(BASE_URI + randomServerPort + "/dropmate/admin/acp/37")
+                .when().delete(BASE_URI + randomServerPort + "/dropmate/admin/acp/40")
                 .then().statusCode(200)
                 .body("message", is("ACP succesfully deleted!"));
     }
 
     @Test
-    @Order(20)
+    @Order(21)
     void deleteACP_withInvalidID_thenThrowException() throws Exception {
         // Performing the call
         RestAssured.given().contentType("application/json")
@@ -436,7 +419,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Order(21)
+    @Order(22)
     void whenGetAllStores_thenReturn_statusOK() throws Exception {
         RestAssured.with().contentType("application/json")
                 .when().get(BASE_URI + randomServerPort + "/dropmate/admin/estores")
@@ -448,7 +431,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Order(22)
+    @Order(23)
     void whenLoginValidUser_thenReturnUser_andStatus200() {
         RestAssured.with().contentType("application/json")
                 .when().post(BASE_URI + randomServerPort + "/dropmate/admin/login?email=" + "user@email.com" + "&password=" + "password")
@@ -459,7 +442,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Order(23)
+    @Order(24)
     void whenLoginWithInvalidEmail_thenReturnStatus401() {
         RestAssured.with().contentType("application/json")
                 .when().post(BASE_URI + randomServerPort + "/dropmate/admin/login?email=" + "invalidemail@email.com" + "&password=" + "password")
@@ -468,7 +451,7 @@ public class DropMate_IntegrationTest {
     }
 
     @Test
-    @Order(24)
+    @Order(25)
     void whenLoginWithInvalidPassword_thenReturnStatus401() {
         RestAssured.with().contentType("application/json")
                 .when().post(BASE_URI + randomServerPort + "/dropmate/admin/login?email=" + "user@email.com" + "&password=" + "invalidPassword")

--- a/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
+++ b/DropMate_Backend/src/test/java/tqs/dropmate/dropmate_backend/serviceTests/AdminService_UnitTest.java
@@ -459,6 +459,20 @@ public class AdminService_UnitTest {
         Mockito.verify(pendingACPRepository, VerificationModeFactory.times(1)).findById(Mockito.any());
     }
 
+    @Test
+    void removeExistingACP() throws ResourceNotFoundException {
+        // Set up Expectations
+        when(acpRepository.findById(1)).thenReturn(Optional.of(pickupPointOne));
+
+        // Verify the result is as expected
+        assertThat(adminService.removeACP(1))
+                .extracting(SuccessfulRequest::getMessage).isEqualTo("ACP succesfully deleted!");
+
+        // Mockito verifications
+        this.verifyFindByIdIsCalled();
+        Mockito.verify(acpRepository, VerificationModeFactory.times(1)).delete(Mockito.any());
+    }
+
     // Auxilliary functions
     private void verifyFindByIdIsCalled(){
         Mockito.verify(acpRepository, VerificationModeFactory.times(1)).findById(Mockito.any());


### PR DESCRIPTION
User Story: Admin Removes an ACP from the Platform, Admin Browses the List of Partnered E-Stores
Jira Code: DM-24 and DM-25

Changes made:

Completed the DELETE "/acp/{acpID}" API endpoints on Admin Controller.
Completed the removeACP() functions on Admin Service.
Tests created:

Admin Service Unit Test: Added the removeExistingACP() tests.
Admin controller boundary test: Added the deleteACP_withValidID_thenACPDeleted(), deleteACP_withInvalidID_thenThrowException()tests.
Integration Test: Created the corresponding tests on this class.